### PR TITLE
Added provider check that was breaking opera browser

### DIFF
--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.0.0",
+  "version": "2.0.0-0.0.1",
   "description": "Injected wallets module for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.0.0-0.0.1",
+  "version": "2.0.1",
   "description": "Injected wallets module for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/injected/src/index.ts
+++ b/packages/injected/src/index.ts
@@ -59,6 +59,7 @@ function injected(options?: InjectedWalletOptions): WalletInit {
 
         if (
           walletExists &&
+          provider &&
           provider.isMetaMask &&
           label !== ProviderLabel.MetaMask &&
           label !== 'Detected Wallet'


### PR DESCRIPTION
### Description
Added provider check that was breaking opera browser

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
