### PR TITLE
Update core version for react components

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Collection of React Hooks for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@web3-onboard/common": "^2.0.1",
-    "@web3-onboard/core": "^2.0.3"
+    "@web3-onboard/core": "^2.0.6"
   },
   "peerDependencies": {
     "react": "^17.0.2"


### PR DESCRIPTION
### Description
Update core version for react components 2.0.3 -> 2.0.6

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
