### PR TITLE
[fix] - Provider Types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ commands:
           name: Build
           command: |
             yarn
+            yarn type-check
             yarn build
       - *save-cache
       - *create-npm-config

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "install-m1-mac": "yarn install --ignore-optional",
     "format": "prettier --write 'packages/**/*.ts'",
     "dev": "yarn wsrun dev",
-    "build": "yarn wsrun build"
+    "build": "yarn wsrun build",
+    "type-check": "yarn wsrun type-check"
   },
   "devDependencies": {
     "prettier": "^2.4.1",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/common",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -384,6 +384,7 @@ export interface EIP1193Provider extends SimpleEventEmitter {
   request(args: EthSignTransactionRequest): Promise<string>
   request(args: EthSignMessageRequest): Promise<string>
   request(args: EIP712Request): Promise<string>
+  request(args: { method: string; params?: Array<unknown> }): Promise<unknown>
   disconnect?(): void
 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
     "build": "rollup -c",
     "dev": "rollup -c -w",
     "start": "sirv public --no-clear",
-    "typescript": "svelte-check --tsconfig ./tsconfig.json",
+    "type-check": "svelte-check --tsconfig ./tsconfig.json",
     "lint": "eslint -c './.eslintrc.cjs' './src' && prettier --check './src/**/*'"
   },
   "typings": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
@@ -40,7 +40,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.0.1",
+    "@web3-onboard/common": "^2.0.2",
     "bowser": "^2.11.0",
     "ethers": "5.5.3",
     "eventemitter3": "^4.0.7",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,8 @@ export type {
   ConnectedChain
 } from './types'
 
+export type { EIP1193Provider } from '@web3-onboard/common'
+
 function init(options: InitOptions): OnboardAPI {
   if (typeof window === 'undefined') return API
 

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -39,6 +39,7 @@
   "license": "MIT",
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack",
-    "dev": "webpack serve"
+    "dev": "webpack serve",
+    "type-check": "exit 0"
   }
 }

--- a/packages/fortmatic/package.json
+++ b/packages/fortmatic/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/gnosis/package.json
+++ b/packages/gnosis/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "test": "ava",
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/keepkey/package.json
+++ b/packages/keepkey/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/mew/package.json
+++ b/packages/mew/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/portis/package.json
+++ b/packages/portis/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/torus/package.json
+++ b/packages/torus/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/trezor/package.json
+++ b/packages/trezor/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -224,7 +224,11 @@ function walletConnect(options?: WalletConnectOptions): WalletInit {
                 )
               }
 
-              return this.providers[chainId].send(method, params)
+              return this.providers[chainId].send(
+                method,
+                // @ts-ignore
+                params
+              )
             }
           }
         }

--- a/packages/walletlink/package.json
+++ b/packages/walletlink/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
-    "test": "ava"
+    "type-check": "tsc --noEmit"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
### Description
**[core:v2.0.7]**
- Export EIP1193 type directly from package
- Update `common` package

**[common:v2.0.2]**
- Add generic request type to EIP1193Provider for ethers External Provider compatibility

**[all-packages]**
- Add `type-check` script and add to CI process
