### PR TITLE
web3-onboard/core:v2.0.9: [enhancement] - Autoselect Disable Modals

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -208,6 +208,11 @@ if (previouslyConnectedWallets) {
   // Connect the most recently connected wallet (first in the array)
   await onboard.connectWallet({ autoSelect: previouslyConnectedWallets[0] })
 
+  // You can also auto connect "silently" and disable all onboard modals to avoid them flashing on page load
+  await onboard.connectWallet({
+    autoSelect: { label: previouslyConnectedWallets[0], disableModals: true }
+  })
+
   // OR - loop through and initiate connection for all previously connected wallets
   // note: This UX might not be great as the user may need to login to each wallet one after the other
   // for (walletLabel in previouslyConnectedWallets) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/core/src/connect.ts
+++ b/packages/core/src/connect.ts
@@ -2,10 +2,12 @@ import { firstValueFrom } from 'rxjs'
 import { filter, withLatestFrom, pluck } from 'rxjs/operators'
 import { state } from './store'
 import { connectWallet$, wallets$ } from './streams'
-import type { ConnectOptions, WalletState } from './types'
+import type { ConnectOptions, ConnectOptionsString, WalletState } from './types'
 import { validateConnectOptions } from './validation'
 
-async function connect(options?: ConnectOptions): Promise<WalletState[]> {
+async function connect(
+  options?: ConnectOptions | ConnectOptionsString
+): Promise<WalletState[]> {
   if (options) {
     const error = validateConnectOptions(options)
     if (error) {
@@ -22,9 +24,17 @@ async function connect(options?: ConnectOptions): Promise<WalletState[]> {
       'At least one chain must be set before attempting to connect a wallet'
     )
 
-  const { autoSelect } = options || { autoSelect: '' }
+  const { autoSelect } = options || {
+    autoSelect: { label: '', disableModals: false }
+  }
 
-  connectWallet$.next({ autoSelect, inProgress: true })
+  connectWallet$.next({
+    autoSelect:
+      typeof autoSelect === 'string'
+        ? { label: autoSelect, disableModals: false }
+        : autoSelect,
+    inProgress: true
+  })
 
   const result$ = connectWallet$.pipe(
     filter(

--- a/packages/core/src/streams.ts
+++ b/packages/core/src/streams.ts
@@ -12,7 +12,7 @@ import {
 import { resetStore } from './store/actions'
 import { state } from './store'
 
-import type { WalletState, InternalState } from './types'
+import type { WalletState, InternalState, ConnectOptions } from './types'
 
 export const reset$ = new Subject<void>()
 export const disconnectWallet$ = new Subject<WalletState['label']>()
@@ -25,7 +25,7 @@ export const internalState$ = new BehaviorSubject<InternalState>({
 })
 
 export const connectWallet$ = new BehaviorSubject<{
-  autoSelect?: string
+  autoSelect?: ConnectOptions['autoSelect']
   actionRequired?: string
   inProgress: boolean
 }>({ inProgress: false, actionRequired: '' })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,7 +30,11 @@ export interface OnboardAPI {
   state: typeof state
 }
 export interface ConnectOptions {
-  autoSelect?: string // wallet name to autoselect for user
+  autoSelect?: { label: string; disableModals: boolean }
+}
+
+export interface ConnectOptionsString {
+  autoSelect?: string
 }
 
 export interface DisconnectOptions {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -5,7 +5,8 @@ import type {
   InitOptions,
   WalletState,
   ConnectOptions,
-  DisconnectOptions
+  DisconnectOptions,
+  ConnectOptionsString
 } from './types'
 
 const chainId = Joi.string().pattern(/^0x[0-9a-fA-F]+$/)
@@ -100,7 +101,13 @@ const initOptions = Joi.object({
 })
 
 const connectOptions = Joi.object({
-  autoSelect: Joi.string()
+  autoSelect: [
+    Joi.object({
+      label: Joi.string().required(),
+      disableModals: Joi.boolean()
+    }),
+    Joi.string()
+  ]
 })
 
 const disconnectOptions = Joi.object({
@@ -133,7 +140,9 @@ export function validateWalletModule(data: WalletModule): ValidateReturn {
   return validate(walletModule, data)
 }
 
-export function validateConnectOptions(data: ConnectOptions): ValidateReturn {
+export function validateConnectOptions(
+  data: ConnectOptions | ConnectOptionsString
+): ValidateReturn {
   return validate(connectOptions, data)
 }
 

--- a/packages/core/src/views/connect/ConnectedWallet.svelte
+++ b/packages/core/src/views/connect/ConnectedWallet.svelte
@@ -1,58 +1,17 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n'
-
-  import { getBalance, getEns } from '../../provider'
-  import { updateAccount } from '../../store/actions'
-  import { connectWallet$, internalState$ } from '../../streams'
-  import { validEnsChain } from '../../utils'
+  import { internalState$ } from '../../streams'
   import success from '../../icons/success'
   import WalletAppBadge from '../shared/WalletAppBadge.svelte'
 
   import type { WalletState } from '../../types'
   import defaultAppIcon from '../../icons/default-app-icon'
   import SuccessStatusIcon from '../shared/SuccessStatusIcon.svelte'
-  import { state } from '../../store'
   import en from '../../i18n/en.json'
 
   export let selectedWallet: WalletState
 
-  const { label } = selectedWallet
   const { appMetadata } = internalState$.getValue()
-
-  async function updateAccountDetails() {
-    const { accounts, chains: selectedWalletChains } = selectedWallet
-    const appChains = state.get().chains
-    const [connectedWalletChain] = selectedWalletChains
-
-    const appChain = appChains.find(
-      ({ namespace, id }) =>
-        namespace === connectedWalletChain.namespace &&
-        id === connectedWalletChain.id
-    )
-
-    const { address } = accounts[0]
-    let { balance, ens } = accounts[0]
-
-    if (balance === null) {
-      getBalance(address, appChain).then(balance => {
-        updateAccount(label, address, {
-          balance
-        })
-      })
-    }
-
-    if (ens === null && validEnsChain(connectedWalletChain.id)) {
-      getEns(address, appChain).then(ens => {
-        updateAccount(label, address, {
-          ens
-        })
-      })
-    }
-
-    setTimeout(() => connectWallet$.next({ inProgress: false }), 1500)
-  }
-
-  updateAccountDetails()
 </script>
 
 <style>

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -6,14 +6,17 @@
   import en from '../../i18n/en.json'
   import { selectAccounts } from '../../provider'
   import { state } from '../../store'
-  import { addWallet } from '../../store/actions'
   import { connectWallet$, internalState$ } from '../../streams'
-  import type {
-    i18n,
-    WalletState,
-    WalletWithLoadedIcon,
-    WalletWithLoadingIcon
-  } from '../../types'
+  import {
+    getChainId,
+    requestAccounts,
+    trackWallet,
+    getBalance,
+    getEns
+  } from '../../provider'
+  import { addWallet, updateAccount } from '../../store/actions'
+  import { validEnsChain } from '../../utils'
+
   import CloseButton from '../shared/CloseButton.svelte'
   import Modal from '../shared/Modal.svelte'
   import Agreement from './Agreement.svelte'
@@ -22,16 +25,23 @@
   import InstallWallet from './InstallWallet.svelte'
   import SelectingWallet from './SelectingWallet.svelte'
   import Sidebar from './Sidebar.svelte'
+  import type {
+    ConnectOptions,
+    i18n,
+    WalletState,
+    WalletWithLoadingIcon
+  } from '../../types'
 
-  export let autoSelect: string
+  export let autoSelect: ConnectOptions['autoSelect']
 
   const { walletModules, appMetadata } = internalState$.getValue()
 
-  let loading = true
   let connectionRejected = false
   let wallets: WalletWithLoadingIcon[] = []
   let selectedWallet: WalletState | null
   let agreed: boolean
+  let connectingWallet: string // the wallet label that is connecting
+  let connectingErrorMessage: string
 
   let windowWidth: number
   let scrollContainer: HTMLElement
@@ -39,70 +49,79 @@
   const walletToAutoSelect =
     autoSelect &&
     walletModules.find(
-      ({ label }) => label.toLowerCase() === autoSelect.toLowerCase()
+      ({ label }) => label.toLowerCase() === autoSelect.label.toLowerCase()
     )
 
-  if (walletToAutoSelect) {
-    autoSelectWallet(walletToAutoSelect)
-  } else {
-    loadWalletsForSelection()
-  }
-
+  // ==== SELECT WALLET ==== //
   async function selectWallet({
     label,
     icon,
     getInterface
-  }: WalletWithLoadedIcon): Promise<void> {
-    const existingWallet = state
-      .get()
-      .wallets.find(wallet => wallet.label === label)
+  }: WalletWithLoadingIcon): Promise<void> {
+    connectingWallet = label
 
-    if (existingWallet) {
-      // set as first wallet
-      addWallet(existingWallet)
+    try {
+      const existingWallet = state
+        .get()
+        .wallets.find(wallet => wallet.label === label)
 
-      try {
-        await selectAccounts(existingWallet.provider)
-        // change step on next event loop
-        setTimeout(() => setStep('connectedWallet'), 1)
-      } catch (error) {
-        const { code } = error as { code: number }
+      if (existingWallet) {
+        // set as first wallet
+        addWallet(existingWallet)
 
-        if (
-          code === ProviderRpcErrorCode.UNSUPPORTED_METHOD ||
-          code === ProviderRpcErrorCode.DOES_NOT_EXIST
-        ) {
-          connectWallet$.next({
-            inProgress: false,
-            actionRequired: existingWallet.label
-          })
+        try {
+          await selectAccounts(existingWallet.provider)
+          // change step on next event loop
+          setTimeout(() => setStep('connectedWallet'), 1)
+        } catch (error) {
+          const { code } = error as { code: number }
+
+          if (
+            code === ProviderRpcErrorCode.UNSUPPORTED_METHOD ||
+            code === ProviderRpcErrorCode.DOES_NOT_EXIST
+          ) {
+            connectWallet$.next({
+              inProgress: false,
+              actionRequired: existingWallet.label
+            })
+          }
         }
+
+        selectedWallet = existingWallet
+
+        return
       }
 
-      selectedWallet = existingWallet
+      const { chains } = state.get()
 
-      return
+      const { provider } = await getInterface({
+        chains,
+        BigNumber,
+        EventEmitter,
+        appMetadata
+      })
+
+      const loadedIcon = await icon
+
+      selectedWallet = {
+        label,
+        icon: loadedIcon,
+        provider,
+        accounts: [],
+        chains: [{ namespace: 'evm', id: '0x1' }]
+      }
+
+      connectingErrorMessage = ''
+
+      // change step on next event loop
+      setTimeout(() => setStep('connectingWallet'), 1)
+    } catch (error) {
+      const { message } = error as { message: string }
+      connectingErrorMessage = message
+      scrollToTop()
+    } finally {
+      connectingWallet = ''
     }
-
-    const { chains } = state.get()
-
-    const { provider } = await getInterface({
-      chains,
-      BigNumber,
-      EventEmitter,
-      appMetadata
-    })
-
-    selectedWallet = {
-      label,
-      icon,
-      provider,
-      accounts: [],
-      chains: [{ namespace: 'evm', id: '0x1' }]
-    }
-
-    // change step on next event loop
-    setTimeout(() => setStep('connectingWallet'), 1)
   }
 
   function deselectWallet() {
@@ -115,10 +134,8 @@
 
   async function autoSelectWallet(wallet: WalletModule): Promise<void> {
     const { getIcon, getInterface, label } = wallet
-    const icon = await getIcon()
+    const icon = getIcon()
     selectWallet({ label, icon, getInterface })
-
-    loading = false
   }
 
   async function loadWalletsForSelection() {
@@ -129,15 +146,109 @@
         getInterface
       }
     })
-
-    loading = false
   }
 
   function close() {
     connectWallet$.next({ inProgress: false })
   }
 
+  // ==== CONNECT WALLET ==== //
+  async function connectWallet() {
+    connectionRejected = false
+
+    const { provider, label } = selectedWallet
+
+    try {
+      const [address] = await requestAccounts(provider)
+
+      // canceled previous request
+      if (!address) {
+        return
+      }
+
+      const chain = await getChainId(provider)
+
+      const update: Pick<WalletState, 'accounts' | 'chains'> = {
+        accounts: [{ address, ens: null, balance: null }],
+        chains: [{ namespace: 'evm', id: chain }]
+      }
+
+      addWallet({ ...selectedWallet, ...update })
+      trackWallet(provider, label)
+      updateSelectedWallet(update)
+      setStep('connectedWallet')
+    } catch (error) {
+      const { code } = error as { code: number; message: string }
+
+      // user rejected account access
+      if (code === ProviderRpcErrorCode.ACCOUNT_ACCESS_REJECTED) {
+        connectionRejected = true
+        return
+      }
+
+      // account access has already been requested and is awaiting approval
+      if (code === ProviderRpcErrorCode.ACCOUNT_ACCESS_ALREADY_REQUESTED) {
+        return
+      }
+    }
+  }
+
+  // ==== CONNECTED WALLET ==== //
+  async function updateAccountDetails() {
+    const { accounts, chains: selectedWalletChains } = selectedWallet
+    const appChains = state.get().chains
+    const [connectedWalletChain] = selectedWalletChains
+
+    const appChain = appChains.find(
+      ({ namespace, id }) =>
+        namespace === connectedWalletChain.namespace &&
+        id === connectedWalletChain.id
+    )
+
+    const { address } = accounts[0]
+    let { balance, ens } = accounts[0]
+
+    if (balance === null) {
+      getBalance(address, appChain).then(balance => {
+        updateAccount(selectedWallet.label, address, {
+          balance
+        })
+      })
+    }
+
+    if (ens === null && validEnsChain(connectedWalletChain.id)) {
+      getEns(address, appChain).then(ens => {
+        updateAccount(selectedWallet.label, address, {
+          ens
+        })
+      })
+    }
+
+    setTimeout(() => connectWallet$.next({ inProgress: false }), 1500)
+  }
+
   let step: keyof i18n['connect'] = 'selectingWallet'
+
+  // ==== STEP HANDLING LOGIC ==== //
+  $: switch (step) {
+    case 'selectingWallet': {
+      if (walletToAutoSelect) {
+        autoSelectWallet(walletToAutoSelect)
+      } else {
+        loadWalletsForSelection()
+      }
+
+      break
+    }
+    case 'connectingWallet': {
+      connectWallet()
+      break
+    }
+    case 'connectedWallet': {
+      updateAccountDetails()
+      break
+    }
+  }
 
   function setStep(update: keyof i18n['connect']) {
     step = update
@@ -222,7 +333,7 @@
 
 <svelte:window bind:innerWidth={windowWidth} />
 
-{#if !loading}
+{#if !autoSelect || (autoSelect && !autoSelect.disableModals)}
   <Modal {close}>
     <div class="container">
       {#if windowWidth >= 809}
@@ -251,7 +362,12 @@
               <Agreement bind:agreed />
 
               <div class:disabled={!agreed}>
-                <SelectingWallet {selectWallet} {wallets} {scrollToTop} />
+                <SelectingWallet
+                  {selectWallet}
+                  {wallets}
+                  {connectingWallet}
+                  {connectingErrorMessage}
+                />
               </div>
             {:else if !autoSelect}
               <InstallWallet />
@@ -260,13 +376,11 @@
 
           {#if step === 'connectingWallet' && selectedWallet}
             <ConnectingWallet
-              on:connectionRejected={({ detail }) => {
-                connectionRejected = detail
-              }}
+              {connectWallet}
+              {connectionRejected}
               {setStep}
               {deselectWallet}
               {selectedWallet}
-              {updateSelectedWallet}
             />
           {/if}
 

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -40,7 +40,7 @@
   let wallets: WalletWithLoadingIcon[] = []
   let selectedWallet: WalletState | null
   let agreed: boolean
-  let connectingWallet: string // the wallet label that is connecting
+  let connectingWalletLabel: string
   let connectingErrorMessage: string
 
   let windowWidth: number
@@ -58,7 +58,7 @@
     icon,
     getInterface
   }: WalletWithLoadingIcon): Promise<void> {
-    connectingWallet = label
+    connectingWalletLabel = label
 
     try {
       const existingWallet = state
@@ -120,7 +120,7 @@
       connectingErrorMessage = message
       scrollToTop()
     } finally {
-      connectingWallet = ''
+      connectingWalletLabel = ''
     }
   }
 
@@ -365,7 +365,7 @@
                 <SelectingWallet
                   {selectWallet}
                   {wallets}
-                  {connectingWallet}
+                  {connectingWalletLabel}
                   {connectingErrorMessage}
                 />
               </div>

--- a/packages/core/src/views/connect/SelectingWallet.svelte
+++ b/packages/core/src/views/connect/SelectingWallet.svelte
@@ -1,38 +1,17 @@
 <script lang="ts">
   import { state } from '../../store'
-  import type { WalletWithLoadedIcon, WalletWithLoadingIcon } from '../../types'
+  import type { WalletWithLoadingIcon } from '../../types'
   import Warning from '../shared/Warning.svelte'
   import WalletButton from './WalletButton.svelte'
 
   export let wallets: WalletWithLoadingIcon[]
-  export let selectWallet: (wallet: WalletWithLoadedIcon) => Promise<void>
-  export let scrollToTop: () => void
-
-  let connecting: string // the wallet label that is connecting
-  let errorMessage: string
+  export let selectWallet: (wallet: WalletWithLoadingIcon) => Promise<void>
+  export let connectingWallet: string
+  export let connectingErrorMessage: string
 
   function checkConnected(label: string) {
     const { wallets } = state.get()
     return !!wallets.find(wallet => wallet.label === label)
-  }
-
-  function select({ label, icon, getInterface }: WalletWithLoadingIcon) {
-    return async () => {
-      connecting = label
-
-      const iconLoaded = await icon
-
-      try {
-        await selectWallet({ label, icon: iconLoaded, getInterface })
-        errorMessage = ''
-      } catch (error) {
-        const { message } = error as { message: string }
-        errorMessage = message
-        scrollToTop()
-      } finally {
-        connecting = ''
-      }
-    }
   }
 </script>
 
@@ -63,9 +42,9 @@
 </style>
 
 <div class="outer-container">
-  {#if errorMessage}
+  {#if connectingErrorMessage}
     <div class="warning-container">
-      <Warning>{@html errorMessage}</Warning>
+      <Warning>{@html connectingErrorMessage}</Warning>
     </div>
   {/if}
 
@@ -73,10 +52,10 @@
     {#each wallets as wallet}
       <WalletButton
         connected={checkConnected(wallet.label)}
-        connecting={connecting === wallet.label}
+        connecting={connectingWallet === wallet.label}
         label={wallet.label}
         icon={wallet.icon}
-        onClick={select(wallet)}
+        onClick={() => selectWallet(wallet)}
       />
     {/each}
   </div>

--- a/packages/core/src/views/connect/SelectingWallet.svelte
+++ b/packages/core/src/views/connect/SelectingWallet.svelte
@@ -6,7 +6,7 @@
 
   export let wallets: WalletWithLoadingIcon[]
   export let selectWallet: (wallet: WalletWithLoadingIcon) => Promise<void>
-  export let connectingWallet: string
+  export let connectingWalletLabel: string
   export let connectingErrorMessage: string
 
   function checkConnected(label: string) {
@@ -52,7 +52,7 @@
     {#each wallets as wallet}
       <WalletButton
         connected={checkConnected(wallet.label)}
-        connecting={connectingWallet === wallet.label}
+        connecting={connectingWalletLabel === wallet.label}
         label={wallet.label}
         icon={wallet.icon}
         onClick={() => selectWallet(wallet)}


### PR DESCRIPTION
### Description
- Lifts all logic out of sub modal components in to the main index for the connect flow
- Modifies type and validation to allow for an options object for the `autoselect` parameter so that modals can be disabled when auto selecting a wallet:

```javascript
const previouslySelectedWallet = window.localStorage.getItem('selectedWalletLabel')

onboard.connectWallet({
  autoSelect: {
    label: previouslyConnectedWallet,
    disableModals: true
  }
})
```

The original way of calling connect wallet with the `autoselect` parameter as a string is also still valid and will get converted to the new options object internally.

Closes #849 