### PR TITLE
fix missing initial states in react hooks

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.0.5",
+  "version": "2.0.4-0.0.1",
   "description": "Collection of React Hooks for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.0.4-0.0.1",
+  "version": "2.0.5",
   "description": "Collection of React Hooks for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Collection of React Hooks for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -34,15 +34,7 @@ export const useConnectWallet = (): [
   useEffect(() => {
     const subscription = (web3Onboard as OnboardAPI).state
       .select('wallets')
-      .subscribe(wallets => {
-        if (!wallet) return
-
-        const updatedWallet = wallets.find(
-          ({ label }) => label === wallet.label
-        )
-
-        updatedWallet && setConnectedWallet(updatedWallet)
-      })
+      .subscribe(wallets => setConnectedWallet(wallets[0] || null))
 
     return () => subscription.unsubscribe()
   }, [wallet])

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -85,11 +85,12 @@ export const useSetChain = (
   const [connectedChain, setConnectedChain] = useState<ConnectedChain | null>(
     () => {
       const initialWallets = (web3Onboard as OnboardAPI).state.get().wallets
+      if (initialWallets.length === 0) return null
       return (
         (
           initialWallets.find(({ label }) => label === walletLabel) ||
           initialWallets[0]
-        )?.chains[0] || null
+        ).chains[0] || null
       )
     }
   )

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -26,7 +26,9 @@ export const useConnectWallet = (): [
 ] => {
   if (!web3Onboard) throw new Error('Must initialize before using hooks.')
 
-  const [wallet, setConnectedWallet] = useState<WalletState | null>(null)
+  const [wallet, setConnectedWallet] = useState<WalletState | null>(
+    () => (web3Onboard as OnboardAPI).state.get().wallets[0] || null
+  )
   const [connecting, setConnecting] = useState(false)
 
   useEffect(() => {
@@ -89,7 +91,15 @@ export const useSetChain = (
   const [settingChain, setInProgress] = useState<boolean>(false)
 
   const [connectedChain, setConnectedChain] = useState<ConnectedChain | null>(
-    null
+    () => {
+      const initialWallets = (web3Onboard as OnboardAPI).state.get().wallets
+      return (
+        (
+          initialWallets.find(({ label }) => label === walletLabel) ||
+          initialWallets[0]
+        )?.chains[0] || null
+      )
+    }
   )
 
   const chains = useMemo(() => state.get().chains, [])
@@ -119,7 +129,9 @@ export const useSetChain = (
 export const useWallets = (): WalletState[] => {
   if (!web3Onboard) throw new Error('Must initialize before using hooks.')
 
-  const [wallets, setConnectedWallets] = useState<WalletState[]>([])
+  const [wallets, setConnectedWallets] = useState<WalletState[]>(
+    () => (web3Onboard as OnboardAPI).state.get().wallets
+  )
 
   useEffect(() => {
     const wallets$ = (web3Onboard as OnboardAPI).state.select('wallets')


### PR DESCRIPTION
### Description
This sets initial react state in the hooks, instead of defaulting to null.

Right now, if a hook is used in a component that renders after you connect your wallet, it won't have any wallets in it's react state. Unless a wallet change happens afterwards that triggers the subscription to update it. Initially, it's all null.
This problem applies to all 3 react hooks.


### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
