### PR TITLE
[fix]: Hardware Wallet Providers Send Transaction

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/common",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -37,6 +37,12 @@ export type RequestPatch = {
         params: EthSignTransactionRequest['params']
       }) => Promise<string>)
     | null
+  eth_sendTransaction?:
+    | ((args: {
+        baseRequest: EIP1193Provider['request']
+        params: EthSignTransactionRequest['params']
+      }) => Promise<string>)
+    | null
   eth_sign?:
     | ((args: {
         baseRequest: EIP1193Provider['request']
@@ -228,7 +234,7 @@ export type ChainId = string
 export type RpcUrl = string
 
 export type WalletInterface = {
-  provider: EIP1193Provider,
+  provider: EIP1193Provider
   instance?: unknown
 }
 

--- a/packages/keepkey/package.json
+++ b/packages/keepkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/keepkey",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "KeepKey module for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/keystone",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Keystone module for web3-onboard",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/keystone/src/index.ts
+++ b/packages/keystone/src/index.ts
@@ -7,8 +7,10 @@ import {
   ProviderRpcErrorCode,
   ProviderRpcError,
   ScanAccountsOptions,
-  WalletInit
+  WalletInit,
+  EIP1193Provider
 } from '@web3-onboard/common'
+
 import type { providers } from 'ethers'
 
 const DEFAULT_BASE_PATH = "m/44'/60'/0'/0"
@@ -125,7 +127,28 @@ function keystone({
           return accounts
         }
 
-        const keystoneProvider = {}
+        const request: EIP1193Provider['request'] = async ({
+          method,
+          params
+        }) => {
+          const response = await fetch(currentChain.rpcUrl, {
+            method: 'POST',
+            body: JSON.stringify({
+              id: '42',
+              method,
+              params
+            })
+          }).then(res => res.json())
+
+          if (response.result) {
+            return response.result
+          } else {
+            throw response.error
+          }
+        }
+
+        const keystoneProvider = { request }
+
         const provider = createEIP1193Provider(keystoneProvider, {
           eth_requestAccounts: async () => {
             // Triggers the account select modal if no accounts have been selected
@@ -196,6 +219,19 @@ function keystone({
             const signedTx = await keyring.signTransaction(from, transaction)
 
             return `0x${signedTx.serialize().toString('hex')}`
+          },
+          eth_sendTransaction: async ({ baseRequest, params }) => {
+            const signedTx = await provider.request({
+              method: 'eth_signTransaction',
+              params
+            })
+
+            const transactionHash = await baseRequest({
+              method: 'eth_sendRawTransaction',
+              params: [signedTx]
+            })
+
+            return transactionHash as string
           },
           eth_sign: async ({ params: [address, message] }) => {
             if (!(accounts && accounts.length && accounts.length > 0))

--- a/packages/keystone/tsconfig.json
+++ b/packages/keystone/tsconfig.json
@@ -9,7 +9,6 @@
     "paths": {
       "*": ["./src/*", "./node_modules/*"]
     },
-    "typeRoots": ["node_modules/@types"],
-    "strict": false
+    "typeRoots": ["node_modules/@types"]
   }
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/ledger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Ledger module for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/ledger/src/index.ts
+++ b/packages/ledger/src/index.ts
@@ -5,7 +5,8 @@ import type {
   Chain,
   CustomNetwork,
   WalletInit,
-  GetInterfaceHelpers
+  GetInterfaceHelpers,
+  EIP1193Provider
 } from '@web3-onboard/common'
 
 // these cannot be dynamically imported
@@ -155,6 +156,7 @@ function ledger({
         const eventEmitter = new EventEmitter()
 
         let currentChain: Chain = chains[0]
+
         const scanAccounts = async ({
           derivationPath,
           chainId,
@@ -223,7 +225,27 @@ function ledger({
           return accounts
         }
 
-        const ledgerProvider = {}
+        const request: EIP1193Provider['request'] = async ({
+          method,
+          params
+        }) => {
+          const response = await fetch(currentChain.rpcUrl, {
+            method: 'POST',
+            body: JSON.stringify({
+              id: '42',
+              method,
+              params
+            })
+          }).then(res => res.json())
+
+          if (response.result) {
+            return response.result
+          } else {
+            throw response.error
+          }
+        }
+
+        const ledgerProvider = { request }
 
         const provider = createEIP1193Provider(ledgerProvider, {
           eth_requestAccounts: async () => {
@@ -326,6 +348,19 @@ function ledger({
             )
 
             return signedTx ? `0x${signedTx.serialize().toString('hex')}` : ''
+          },
+          eth_sendTransaction: async ({ baseRequest, params }) => {
+            const signedTx = await provider.request({
+              method: 'eth_signTransaction',
+              params
+            })
+
+            const transactionHash = await baseRequest({
+              method: 'eth_sendRawTransaction',
+              params: [signedTx]
+            })
+
+            return transactionHash as string
           },
           eth_sign: async ({ params: [address, message] }) => {
             if (!(accounts && accounts.length && accounts.length > 0))

--- a/packages/trezor/package.json
+++ b/packages/trezor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/trezor",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Trezor module for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",


### PR DESCRIPTION
### Description
- Adds `request` function to provider, so that all unpatched RPC methods will get forwarded on to the connected RPC endpoint
- Patches `eth_sendTransaction` RPC method to sign transaction and then send the raw transaction to the RPC endpoint

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
