### PR TITLE
use tally only namespace

### DIFF
--- a/packages/injected/src/types.ts
+++ b/packages/injected/src/types.ts
@@ -85,6 +85,7 @@ export interface BinanceProvider extends EIP1193Provider {
 export enum InjectedNameSpace {
   Ethereum = 'ethereum',
   Binance = 'BinanceChain',
+  Tally = 'tally',
   Web3 = 'web3',
   Arbitrum = 'arbitrum',
   XFI = 'xfi'
@@ -94,6 +95,7 @@ export enum InjectedNameSpace {
 export interface CustomWindow extends Window {
   BinanceChain: BinanceProvider
   ethereum: InjectedProvider
+  tally: InjectedProvider
   web3: ExternalProvider | MeetOneProvider
   arbitrum: InjectedProvider
   xfi: {

--- a/packages/injected/src/wallets.ts
+++ b/packages/injected/src/wallets.ts
@@ -445,19 +445,17 @@ const tokenary: InjectedWalletModule = {
 
 const tally: InjectedWalletModule = {
   label: ProviderLabel.Tally,
-  injectedNamespace: InjectedNameSpace.Ethereum,
+  injectedNamespace: InjectedNameSpace.Tally,
   checkProviderIdentity: ({ provider }) =>
     !!provider && !!provider[ProviderIdentityFlag.Tally],
   getIcon: async () => (await import('./icons/tallywallet.js')).default,
   getInterface: async () => {
-    const provider = createEIP1193Provider(window.ethereum, {
-      eth_chainId: ({ baseRequest }) => baseRequest({ method: 'eth_chainId' }).then(id => `0x${parseInt(id).toString(16)}`),
-    });
-    provider.removeListener = (event, func) => { };
+    const provider = createEIP1193Provider(window.tally)
+    provider.removeListener = (event, func) => {}
     return {
-        provider
-    };
-},
+      provider
+    }
+  },
   platforms: ['desktop']
 }
 


### PR DESCRIPTION
### Description

The infrasture is there to be able to detect
multiple injected provider which is awesome!
I am honestly grateful for this!

But if we use mostly window.ethereum we
kinda beat the purpose of the whole infrasturcure
being there.

So let's use wallet specific namespaces.

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
> This is a PR for a feature branch, I assume this does not apply here
- [ ] The box that allows repo maintainers to update this PR is checked
> I think I can't do that on an organization owned fork :(
- [x] I tested locally to make sure this feature/fix works
> Tested with https://github.com/blocknative/react-demo and `yarn link @web3-onboard/injected-wallets ` and the latest main on tally 
- [ ] This PR passes the Circle CI checks
> Not sure :(