### PR TITLE
fix: exports i18n/en.json to dist

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
@@ -22,6 +22,7 @@
     "@rollup/plugin-node-resolve": "^11.0.0",
     "@rollup/plugin-replace": "^3.0.0",
     "@rollup/plugin-typescript": "^8.0.0",
+    "@rollup-extras/plugin-copy": "~1.2.2",
     "@tsconfig/svelte": "^2.0.0",
     "@types/lodash.merge": "^4.6.6",
     "@types/lodash.partition": "^4.6.6",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -4,6 +4,7 @@ import replace from '@rollup/plugin-replace'
 import json from '@rollup/plugin-json'
 import sveltePreprocess from 'svelte-preprocess'
 import typescript from '@rollup/plugin-typescript'
+import copy from '@rollup-extras/plugin-copy';
 
 const production = !process.env.ROLLUP_WATCH
 
@@ -33,6 +34,10 @@ export default {
     typescript({
       sourceMap: !production,
       inlineSources: !production
+    }),
+    copy({
+      src: 'src/i18n/en.json',
+      dest: 'i18n'
     })
   ],
   external: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,6 +1028,13 @@
     jsbi "^3.1.5"
     sha.js "^2.4.11"
 
+"@niceties/logger@^1.1.0":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@niceties/logger/-/logger-1.1.3.tgz#f560e9e12c7d3c946d369ee1f9a5668a2767c95f"
+  integrity sha512-OdqmQMMvCiMFiHcjqhsw2D07mwNsqVQEKVbi5J2XrRX5gWPRVnEzp0nF0dtcSwfWOS8oyIHs7Z7b+x2q73sgPA==
+  dependencies:
+    kleur "^4.1.4"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1058,6 +1065,26 @@
     penpal "3.0.7"
     pocket-js-core "0.0.3"
     web3-provider-engine "16.0.1"
+
+"@rollup-extras/plugin-copy@~1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@rollup-extras/plugin-copy/-/plugin-copy-1.2.2.tgz#77cb6b94d36df25ab008535760fd6ab1321aab34"
+  integrity sha512-BWhAGzzmkMrqePl/SBr2UgQjYv7cG6cXkMXUDkVN8oy+q+EwQoCYqmM2KskuTVHqbHM31qEbT+uj6YGpf3pzGA==
+  dependencies:
+    "@niceties/logger" "^1.1.0"
+    "@rollup-extras/utils" "^1.2.0"
+    "@types/glob" "^7.2.0"
+    "@types/glob-parent" "^5.1.1"
+    glob "^7.2.0"
+    glob-parent "^6.0.2"
+    glob-promise "^4.2.2"
+
+"@rollup-extras/utils@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@rollup-extras/utils/-/utils-1.2.0.tgz#1c94c19fb7103b220ceec82439c32eebaf7aea98"
+  integrity sha512-kH3xcoKvUeS3k/ZSo/d2njb9ajEApm7cDoklNHEypnRZga8fjqcxn9J+qcae3iQLiO1aPyQCR8ZRsOV+6ZD2Gg==
+  dependencies:
+    "@niceties/logger" "^1.1.0"
 
 "@rollup/plugin-babel@^5.3.0":
   version "5.3.1"
@@ -1441,6 +1468,19 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/glob-parent@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@types/glob-parent/-/glob-parent-5.1.1.tgz#eb83d64824374495437b450d45e24ec53a7ce844"
+  integrity sha512-r2rwLjU4mYJmX3S81d8KxCboZOGPVEN5hvtYKzQ0aFNRhYir3DIVf8Hlznr65Wk748swi6hhccsDo3MyydHb2A==
+
+"@types/glob@^7.1.3", "@types/glob@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/http-proxy@^1.17.8":
   version "1.17.8"
   resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.8.tgz#968c66903e7e42b483608030ee85800f22d03f55"
@@ -1518,6 +1558,11 @@
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
   integrity sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==
+
+"@types/minimatch@*":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
+  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*", "@types/node@17.0.19":
   version "17.0.19"
@@ -4937,6 +4982,20 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
+glob-promise@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/glob-promise/-/glob-promise-4.2.2.tgz#15f44bcba0e14219cd93af36da6bb905ff007877"
+  integrity sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==
+  dependencies:
+    "@types/glob" "^7.1.3"
+
 glob-to-regexp@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
@@ -4954,7 +5013,7 @@ glob@7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.2, glob@^7.1.3, glob@^7.1.6:
+glob@^7.1.2, glob@^7.1.3, glob@^7.1.6, glob@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -5547,7 +5606,7 @@ is-generator-function@^1.0.7:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -6002,6 +6061,11 @@ kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+kleur@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.4.tgz#8c202987d7e577766d039a8cd461934c01cda04d"
+  integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
 
 level-codec@~7.0.0:
   version "7.0.1"


### PR DESCRIPTION
### Description
<!-- Add a description of the fix or feature here -->

This PR copies `src/i18n/en.json` to the dist directory to avoid breaking types during a build with vite.

fixes: #913

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
