### PR TITLE
1.38.3: [fix] - Opera Provider Detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.38.2",
+  "version": "1.38.3",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/opera.ts
+++ b/src/modules/select/wallets/opera.ts
@@ -13,16 +13,15 @@ function opera(options: CommonWalletOptions): WalletModule {
     iconSrcSet: iconSrc || operaIcon2x,
     svg,
     wallet: async (helpers: Helpers) => {
-      const { getProviderName, createModernProviderInterface } = helpers
+      const { getProviderName, createModernProviderInterface, browser } =
+        helpers
 
-      const provider =
-        (window as any).ethereum ||
-        ((window as any).web3 && (window as any).web3.currentProvider)
+      const provider = (window as any).ethereum
 
       return {
         provider,
         interface:
-          provider && getProviderName(provider) === undefined
+          provider && browser.name === 'Opera'
             ? createModernProviderInterface(provider)
             : null
       }

--- a/src/modules/select/wallets/opera.ts
+++ b/src/modules/select/wallets/opera.ts
@@ -3,6 +3,7 @@ import { WalletModule, Helpers, CommonWalletOptions } from '../../../interfaces'
 
 import operaIcon from '../wallet-icons/icon-opera.png'
 import operaIcon2x from '../wallet-icons/icon-opera@2x.png'
+import { getProviderName } from '../../../utilities'
 
 function opera(options: CommonWalletOptions): WalletModule {
   const { preferred, label, iconSrc, svg } = options
@@ -19,7 +20,7 @@ function opera(options: CommonWalletOptions): WalletModule {
       return {
         provider,
         interface:
-          provider && browser.name === 'Opera'
+          provider && getProviderName(provider) === 'Opera'
             ? createModernProviderInterface(provider)
             : null
       }

--- a/src/modules/select/wallets/opera.ts
+++ b/src/modules/select/wallets/opera.ts
@@ -13,9 +13,7 @@ function opera(options: CommonWalletOptions): WalletModule {
     iconSrcSet: iconSrc || operaIcon2x,
     svg,
     wallet: async (helpers: Helpers) => {
-      const { getProviderName, createModernProviderInterface, browser } =
-        helpers
-
+      const { createModernProviderInterface, browser } = helpers
       const provider = (window as any).ethereum
 
       return {


### PR DESCRIPTION
### Description
- Switches Opera detection to using the provider flag now that it is consistent across environments
- Updates CI for new branch naming

Closes #908 

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
