### PR TITLE
[core-v2.2.1] : Fix - Add check for connection rejection when autoSelecting Wallet

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -47,7 +47,7 @@
   let windowWidth: number
   let scrollContainer: HTMLElement
 
-  const walletToAutoSelect =
+  let walletToAutoSelect =
     autoSelect &&
     walletModules.find(
       ({ label }) => label.toLowerCase() === autoSelect.label.toLowerCase()
@@ -185,6 +185,12 @@
       // user rejected account access
       if (code === ProviderRpcErrorCode.ACCOUNT_ACCESS_REJECTED) {
         connectionRejected = true
+        if (autoSelect && walletToAutoSelect && walletToAutoSelect.label === label){
+            deselectWallet();
+            console.log(autoSelect, label)
+            walletToAutoSelect = null;
+            setStep('selectingWallet');
+          }
         return
       }
 
@@ -234,7 +240,7 @@
   // ==== STEP HANDLING LOGIC ==== //
   $: switch (step) {
     case 'selectingWallet': {
-      if (walletToAutoSelect && !connectionRejected) {
+      if (walletToAutoSelect) {
         autoSelectWallet(walletToAutoSelect)
       } else {
         loadWalletsForSelection()

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -127,6 +127,7 @@
   }
 
   function deselectWallet() {
+    state
     selectedWallet = null
   }
 
@@ -234,7 +235,7 @@
   // ==== STEP HANDLING LOGIC ==== //
   $: switch (step) {
     case 'selectingWallet': {
-      if (walletToAutoSelect) {
+      if (walletToAutoSelect && !connectionRejected) {
         autoSelectWallet(walletToAutoSelect)
       } else {
         loadWalletsForSelection()

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -127,7 +127,6 @@
   }
 
   function deselectWallet() {
-    state
     selectedWallet = null
   }
 


### PR DESCRIPTION
### Description
Add check for connection rejection when autoSelecting Wallet to close out [928](https://github.com/blocknative/web3-onboard/issues/928)

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
