### PR TITLE
[magic-v2.0.1] : Fix - Increase login modal z-index and expose as external variable

### DIFF
--- a/packages/magic/src/login-modal.ts
+++ b/packages/magic/src/login-modal.ts
@@ -83,6 +83,9 @@ const mountLoginModal = (
         /* SPACING */
         --margin-4: 1rem;
         --margin-5: 0.5rem;
+
+        /* MODAL POSITIONING */
+        --z-index: 25;
       }
 
     </style>

--- a/packages/magic/src/view/LoginModal.svelte
+++ b/packages/magic/src/view/LoginModal.svelte
@@ -120,7 +120,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    z-index: 20;
+    z-index: var(--login-modal-z-index, var(--z-index));
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
### Description
Increase login modal z-index and expose as external variable to handle [928](https://github.com/blocknative/web3-onboard/issues/932)


### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
