### PR TITLE
[fix]: Add z-index to wallet row menu

### DIFF
--- a/packages/core/src/views/account-center/WalletRow.svelte
+++ b/packages/core/src/views/account-center/WalletRow.svelte
@@ -125,6 +125,7 @@
     padding: 0;
     border: none;
     overflow: hidden;
+    z-index: 1;
   }
 
   .menu li {


### PR DESCRIPTION
### Description
This PR fixes a UI bug where some text was showing in the wallet row menu that shouldn't be due to lacking a z-index.

### Checklist
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
