### PR TITLE
[core] : Enhancement - Dropdown select icon opens options

### DIFF
--- a/packages/core/src/icons/caret-light.ts
+++ b/packages/core/src/icons/caret-light.ts
@@ -1,5 +1,1 @@
-export default `
-  <svg width="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M16.59 8.59L12 13.17L7.41 8.59L6 10L12 16L18 10L16.59 8.59Z" fill="currentColor"/>
-  </svg>
-`
+export default `<svg width="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M16.59 8.59L12 13.17L7.41 8.59L6 10L12 16L18 10L16.59 8.59Z" fill="currentColor"/></svg>`

--- a/packages/core/src/icons/caret.ts
+++ b/packages/core/src/icons/caret.ts
@@ -1,5 +1,1 @@
-export default `
-  <svg width="100%" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M7 10L12 15L17 10H7Z" fill="currentColor"/>
-  </svg>
-`
+export default `<svg width="100%" height="24" viewBox="0 5 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M7 10L12 15L17 10H7Z" fill="currentColor"/></svg>`

--- a/packages/core/src/views/account-center/Maximized.svelte
+++ b/packages/core/src/views/account-center/Maximized.svelte
@@ -321,9 +321,6 @@
               bold={true}
               selectIcon={caretLightIcon}
             />
-            <!-- <div class="caret flex items-center justify-center">
-              {@html caretLightIcon}
-            </div> -->
           </div>
         </div>
       </div>

--- a/packages/core/src/views/account-center/Maximized.svelte
+++ b/packages/core/src/views/account-center/Maximized.svelte
@@ -319,10 +319,11 @@
               chains={appChains}
               color="#33394B"
               bold={true}
+              selectIcon={caretLightIcon}
             />
-            <div class="caret flex items-center justify-center">
+            <!-- <div class="caret flex items-center justify-center">
               {@html caretLightIcon}
-            </div>
+            </div> -->
           </div>
         </div>
       </div>

--- a/packages/core/src/views/account-center/Minimized.svelte
+++ b/packages/core/src/views/account-center/Minimized.svelte
@@ -203,12 +203,13 @@
               : warningIcon}
           </div>
 
-          <NetworkSelector {chains} color="#33394B" />
+          <NetworkSelector {chains} color="#33394B" selectIcon={caretIcon}
+          />
         </div>
 
-        <div class="caret flex items-center">
+        <!-- <div class="caret flex items-center">
           {@html caretIcon}
-        </div>
+        </div> -->
       </div>
     </div>
   </div>

--- a/packages/core/src/views/account-center/Minimized.svelte
+++ b/packages/core/src/views/account-center/Minimized.svelte
@@ -40,8 +40,7 @@
       ? firstAccount.balance[firstAddressAsset]
       : null
 
-  $: primaryChain =
-    primaryWallet && primaryWallet.chains[0]
+  $: primaryChain = primaryWallet && primaryWallet.chains[0]
 
   $: validAppChain = chains.find(({ id, namespace }) =>
     primaryChain
@@ -203,8 +202,7 @@
               : warningIcon}
           </div>
 
-          <NetworkSelector {chains} color="#33394B" selectIcon={caretIcon}
-          />
+          <NetworkSelector {chains} color="#33394B" selectIcon={caretIcon} />
         </div>
       </div>
     </div>

--- a/packages/core/src/views/account-center/Minimized.svelte
+++ b/packages/core/src/views/account-center/Minimized.svelte
@@ -206,10 +206,6 @@
           <NetworkSelector {chains} color="#33394B" selectIcon={caretIcon}
           />
         </div>
-
-        <!-- <div class="caret flex items-center">
-          {@html caretIcon}
-        </div> -->
       </div>
     </div>
   </div>

--- a/packages/core/src/views/shared/NetworkSelector.svelte
+++ b/packages/core/src/views/shared/NetworkSelector.svelte
@@ -102,7 +102,9 @@
       bind:this={selectElement}
       value={wallet.chains[0].id}
       on:change={handleSelect}
-      style={`color: ${color}; background-image: url('data:image/svg+xml;utf8,${selectIcon}'); ${bold ? 'font-weight: 700;' : ''}`}
+      style={`color: ${color}; background-image: url('data:image/svg+xml;utf8,${selectIcon}'); ${
+        bold ? 'font-weight: 700;' : ''
+      }`}
     >
       {#if !connectedToValidAppChain(wallet.chains[0], chains)}
         <option value={wallet.chains[0].id}

--- a/packages/core/src/views/shared/NetworkSelector.svelte
+++ b/packages/core/src/views/shared/NetworkSelector.svelte
@@ -5,7 +5,9 @@
   import setChain from '../../chain'
   import { wallets$ } from '../../streams'
   import { distinctUntilChanged, debounceTime, skip } from 'rxjs/operators'
+  import caretIcon from '../../icons/caret'
 
+  export let selectIcon: string = caretIcon
   export let color = '#33394B'
   export let chains: Chain[]
   export let bold = false
@@ -72,8 +74,13 @@
     font-size: var(--onboard-font-size-7, var(--font-size-7));
     line-height: var(--onboard-font-line-height-3, var(--font-line-height-3));
     max-width: 90px;
-    width: 54px;
+    min-width: 72px;
     transition: width 250ms ease-in-out;
+    background-repeat: no-repeat, repeat;
+    background-position: right 0px top 0px, 0 0;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    padding: 0 16px 0 0;
   }
 
   select:focus {
@@ -95,7 +102,7 @@
       bind:this={selectElement}
       value={wallet.chains[0].id}
       on:change={handleSelect}
-      style={`color: ${color}; ${bold ? 'font-weight: 700;' : ''}`}
+      style={`color: ${color}; background-image: url('data:image/svg+xml;utf8,${selectIcon}'); ${bold ? 'font-weight: 700;' : ''}`}
     >
       {#if !connectedToValidAppChain(wallet.chains[0], chains)}
         <option value={wallet.chains[0].id}

--- a/packages/core/src/views/shared/NetworkSelector.svelte
+++ b/packages/core/src/views/shared/NetworkSelector.svelte
@@ -95,7 +95,7 @@
 
 {#if wallet}
   {#if $switching$}
-    <span style={`color: ${color};`}>switching...</span>
+    <span style={`color: ${color}; padding: 0 12px 0 8px;`}>switching...</span>
   {:else}
     <select
       class="flex justify-center items-center pointer"


### PR DESCRIPTION
### Description
Prior to this change the chevron(caret) icons were not selectable and did not open the network drop-down. 
With this change the icons are passed from the parent element and therefore can be custom to the component.
The icon is then used as a background image within the select giving a more understandable UX
For this to work the line breaks needed to be removed form the caret icons and min-width for select increased.

<img width="331" alt="Screen Shot 2022-04-15 at 11 47 12 AM" src="https://user-images.githubusercontent.com/24457880/163604552-2891fa76-44e7-4cac-bc1e-7ac2f91a0b8a.png">
<img width="354" alt="Screen Shot 2022-04-15 at 11 47 07 AM" src="https://user-images.githubusercontent.com/24457880/163604554-7667b716-bf96-48a9-a5f3-d8970fec4a49.png">
<img width="342" alt="Screen Shot 2022-04-18 at 8 21 45 PM" src="https://user-images.githubusercontent.com/24457880/163907730-f088c468-f8e3-45d3-b6f8-d1473d7f6969.png">

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
