### PR TITLE
[fix] Fix account joi error

### DIFF
--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -47,11 +47,11 @@ const balance = Joi.any().allow(
   null
 )
 
-const account = {
+const account = Joi.object({
   address: Joi.string().required(),
   ens,
   balance
-}
+})
 
 const chains = Joi.array().items(chain)
 const accounts = Joi.array().items(account)


### PR DESCRIPTION
### Description
Looks like the account validator patten miss object

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
