### PR TITLE
[trezor-v2.0.5] : Fix - Update handling of addresses when getting balance - coercing to lowercase

### DIFF
--- a/packages/trezor/package.json
+++ b/packages/trezor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/trezor",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Trezor module for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/trezor/src/index.ts
+++ b/packages/trezor/src/index.ts
@@ -173,7 +173,7 @@ function trezor(options: TrezorOptions): WalletInit {
                 address,
                 balance: {
                   asset: asset.label,
-                  value: await provider.getBalance(address)
+                  value: await provider.getBalance(address.toLowerCase())
                 }
               }
             ]
@@ -224,6 +224,7 @@ function trezor(options: TrezorOptions): WalletInit {
 
             return result.payload.address
           } catch (error) {
+            console.error(error)
             throw new Error(errorMsg)
           }
         }


### PR DESCRIPTION
### Description
Some coin specific custom derivation path addresses (coin 137 - RBTC) returned by Trezor do not pass the checksum validation when getting balance from ethers.js
The fix was to coerce the address to lowercase in the balance check method. 

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
