### PR TITLE
1.38.2-0.0.1 : [fix] - Update trezor module to not validate path using old method

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.38.2",
+  "version": "1.38.2-0.0.1",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bnc-onboard",
-  "version": "1.38.2-0.0.1",
+  "version": "1.38.3",
   "description": "Onboard users to web3 by allowing them to select a wallet, get that wallet ready to transact and have access to synced wallet state.",
   "keywords": [
     "ethereum",

--- a/src/modules/select/wallets/keystone.ts
+++ b/src/modules/select/wallets/keystone.ts
@@ -195,7 +195,7 @@ async function keystoneProvider(options: {
     const accounts = [...addressToIndex.entries()]
     const account = accounts.find(
       ([accountAddress]) => accountAddress === address
-    )!
+    )
     const accountIndex = accounts.findIndex(
       ([accountAddress]) => accountAddress === address
     )

--- a/src/modules/select/wallets/trezor.ts
+++ b/src/modules/select/wallets/trezor.ts
@@ -84,7 +84,7 @@ async function trezorProvider(options: {
   const { default: Common } = await import('@ethereumjs/common')
   const ethUtil = await import('ethereumjs-util')
   const { default: createProvider } = await import('./providerEngine')
-  const { generateAddresses, isValidPath } = await import('./hd-wallet')
+  const { generateAddresses } = await import('./hd-wallet')
 
   const { default: TrezorConnect, DEVICE_EVENT, DEVICE } = TrezorConnectLibrary
 

--- a/src/modules/select/wallets/trezor.ts
+++ b/src/modules/select/wallets/trezor.ts
@@ -178,9 +178,6 @@ async function trezorProvider(options: {
   }
 
   async function setPath(path: string, custom?: boolean) {
-    if (!isValidPath(path)) {
-      return false
-    }
 
     if (path !== dPath) {
       // clear any exsting addresses if different path
@@ -323,7 +320,7 @@ async function trezorProvider(options: {
       addresses.map(
         address =>
           new Promise(async resolve => {
-            const balance = await getBalance(address)
+            const balance = await getBalance(address.toLowerCase())
             resolve({ address, balance })
           })
       )

--- a/src/modules/select/wallets/trezor.ts
+++ b/src/modules/select/wallets/trezor.ts
@@ -178,7 +178,6 @@ async function trezorProvider(options: {
   }
 
   async function setPath(path: string, custom?: boolean) {
-
     if (path !== dPath) {
       // clear any exsting addresses if different path
       addressToPath = new Map()


### PR DESCRIPTION
### Description
Update trezor module to not validate path using old method

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
