### PR TITLE
Update the react peerdep to not peg to React 17

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,6 @@
     "@web3-onboard/common": "^2.1.0-alpha.1"
   },
   "peerDependencies": {
-    "react": "^17.0.2"
+    "react": ">=16.8"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.1.7-alpha.4",
+  "version": "2.1.7-alpha.5",
   "description": "Collection of React Hooks for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",


### PR DESCRIPTION
This package is currently pegged by peer dependency to React 17, which is likely to be the least adopted React version in a while, given that it was a glorified minor version before React 18. This peer dep should be more than fine for what this package does, and just increases compatibility without causing problems for users that are now able to use the package where they wouldn't be allowed to before.

Currently this package _should_ be compatible with React 16, 17, and 18. But the Peer Deps listed basically disallow you from having any react packages that aren't in V17, which is almost certainly not the desired behavior, and a pretty annoying consequence of using the package currently. There's another PR (https://github.com/blocknative/web3-onboard/pull/915) that upgrades to React 18, but that isn't necessarily as compatible as this change and should be a lot easier to get through.

### Description
<!-- Add a description of the fix or feature here -->

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
