### PR TITLE
Feature: optional public RPC and block explorer Chain params

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/common",
-  "version": "2.1.2",
+  "version": "2.1.2-alpha.1",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/common",
-  "version": "2.1.1-alpha.1",
+  "version": "2.1.1-alpha.2",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -430,6 +430,8 @@ export interface Chain {
   color?: string
   icon?: string // svg string
   providerConnectionInfo?: ConnectionInfo
+  publicRpcUrl?: string
+  blockExplorerUrl?: string
 }
 
 export type TokenSymbol = string // eg ETH

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -49,6 +49,8 @@ type Chain = {
   token: TokenSymbol // the native token symbol, eg ETH, BNB, MATIC
   color?: string // the color used to represent the chain and will be used as a background for the icon
   icon?: string // the icon to represent the chain
+  publicRpcUrl?: string // an optional public RPC used when adding a new chain config to the wallet
+  blockExplorerUrl?: string // also used when adding a new config to the wallet
 }
 ```
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.2.13",
+  "version": "2.2.13-alpha.1",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.2.12-alpha.1",
+  "version": "2.2.12-alpha.2",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
@@ -41,7 +41,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.1-alpha.1",
+    "@web3-onboard/common": "^2.1.1-alpha.2",
     "bowser": "^2.11.0",
     "ethers": "5.5.3",
     "eventemitter3": "^4.0.7",

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -324,7 +324,8 @@ export function addNewChain(
           symbol: chain.token,
           decimals: 18
         },
-        rpcUrls: [chain.rpcUrl]
+        rpcUrls: [chain.publicRpcUrl || chain.rpcUrl],
+        blockExplorerUrls: chain.blockExplorerUrl ? [chain.blockExplorerUrl] : undefined
       }
     ]
   })

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -1,5 +1,5 @@
-import Joi from 'joi'
-import type { ChainId, WalletInit, WalletModule } from '@web3-onboard/common'
+import Joi, { ObjectSchema, Schema } from 'joi'
+import type { Chain, ChainId, WalletInit, WalletModule } from '@web3-onboard/common'
 
 import type {
   InitOptions,
@@ -29,7 +29,7 @@ const providerConnectionInfo = Joi.object({
   timeout: Joi.number()
 })
 
-const chain = Joi.object({
+const chainValidationParams: Record<keyof Chain, Schema | ObjectSchema> = {
   namespace: chainNamespace,
   id: chainId.required(),
   rpcUrl: Joi.string().required(),
@@ -37,8 +37,11 @@ const chain = Joi.object({
   token: Joi.string().required(),
   icon: Joi.string(),
   color: Joi.string(),
-  providerConnectionInfo: providerConnectionInfo
-})
+  publicRpcUrl: Joi.string(),
+  blockExplorerUrl: Joi.string(),
+  providerConnectionInfo
+}
+const chain = Joi.object(chainValidationParams)
 
 const connectedChain = Joi.object({
   namespace: chainNamespace.required(),
@@ -208,6 +211,7 @@ export function validateString(str: string): ValidateReturn {
 
 export function validateSetChainOptions(data: {
   chainId: ChainId
+  chainNamespace?: string
   wallet?: WalletState['label']
 }): ValidateReturn {
   return validate(setChainOptions, data)

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.1.9",
+  "version": "2.1.10-alpha.1",
   "description": "Collection of React Hooks for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",
@@ -23,8 +23,8 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.2.12",
-    "@web3-onboard/common": "^2.1.1",
+    "@web3-onboard/core": "^2.2.13-alpha.1",
+    "@web3-onboard/common": "^2.1.2-alpha.1",
     "use-sync-external-store": "1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
Resolves #1020 and #948.

As outlined in #1020, it's sometimes necessary to pass a custom (typically public) RPC when adding a new chain to the user's wallet.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
