### PR TITLE
[core] : feature - Add background styling variable to the Action Required modal

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -508,6 +508,9 @@ The Onboard styles can customized via [CSS variables](https://developer.mozilla.
   --onboard-modal-backdrop
   --onboard-modal-box-shadow
 
+  /* CUSTOMIZE THE ACTION REQUIRED MODAL */
+  --onboard-action-required-modal-background
+
   /* FONTS */
   --onboard-font-family-normal: Sofia Pro;
   --onboard-font-family-semibold: Sofia Pro Semibold;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.2.9-alpha.5",
+  "version": "2.2.9-alpha.4",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.2.9-alpha.4",
+  "version": "2.2.9-alpha.5",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/core/src/views/account-center/Maximized.svelte
+++ b/packages/core/src/views/account-center/Maximized.svelte
@@ -134,10 +134,6 @@
     line-height: var(--onboard-font-line-height-3, var(--font-line-height-3));
   }
 
-  .caret {
-    width: 16px;
-  }
-
   .app-info-container {
     background: var(--onboard-white, var(--white));
     border-radius: 16px;

--- a/packages/core/src/views/account-center/Minimized.svelte
+++ b/packages/core/src/views/account-center/Minimized.svelte
@@ -98,10 +98,6 @@
     margin-right: 4px;
   }
 
-  .caret {
-    width: 24px;
-  }
-
   .container {
     border: 1px solid transparent;
     border-radius: 16px;

--- a/packages/core/src/views/connect/ActionRequired.svelte
+++ b/packages/core/src/views/connect/ActionRequired.svelte
@@ -18,6 +18,10 @@
     font-family: var(--onboard-font-family-normal, var(--font-family-normal));
     font-size: var(--onboard-font-size-5, var(--font-size-5));
     line-height: 24px;
+    background: var(
+      --onboard-action-required-modal-background,
+      var(--onboard-white, var(--white))
+    );
   }
 
   .icon-container {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.1.7-alpha.5",
+  "version": "2.1.7-alpha.6",
   "description": "Collection of React Hooks for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",
@@ -21,7 +21,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.2.9-alpha.4",
+    "@web3-onboard/core": "^2.2.9-alpha.5",
     "@web3-onboard/common": "^2.1.0-alpha.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

- Add background styling variable to the Action Required modal `--onboard-action-required-modal-background` with fallbacks closing #1013 
- Remove unused styling classes causing warning in build
<img width="880" alt="Screen Shot 2022-05-27 at 9 24 32 AM" src="https://user-images.githubusercontent.com/24457880/170730141-2fd6a650-b0c1-4df1-93e8-24cf48475ec1.png">


### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
