### PR TITLE
fix(keystone): use let for AirGappedKeyring const

### DIFF
--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/keystone",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Keystone module for web3-onboard",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/keystone",
-  "version": "2.1.1",
+  "version": "2.1.1-alpha.1",
   "description": "Keystone module for web3-onboard",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/keystone/src/index.ts
+++ b/packages/keystone/src/index.ts
@@ -79,7 +79,7 @@ function keystone({
           '@ethersproject/providers'
         )
 
-        const { default: AirGappedKeyring } = await import(
+        let { default: AirGappedKeyring } = await import(
           '@keystonehq/eth-keyring'
         )
 


### PR DESCRIPTION
### Description
Use let assignment for AirGappedKeyring as its currently using const and then reassigning variable

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
