### PR TITLE
[injected][dcent] - Fixes clashing svg vars

### DIFF
--- a/packages/dcent/package.json
+++ b/packages/dcent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/dcent",
-  "version": "1.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "D'CENT module for web3-onboard",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/dcent/src/icon.ts
+++ b/packages/dcent/src/icon.ts
@@ -1,23 +1,22 @@
-
-export default `<svg xmlns="http://www.w3.org/2000/svg" id="_171_4" width="100%" height="100%" viewBox="0 0 48 48">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+export default `<svg xmlns="http://www.w3.org/2000/svg" id="dcent-_171_4" width="100%" height="100%" viewBox="0 0 48 48">
+<svg version="1.1" id="dcent-Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 62.27 71.11" style="enable-background:new 0 0 62.27 71.11;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#B3B5B5;}
-	.st1{fill:#72BFBC;}
-	.st2{fill:#6D6E70;}
+	.dcent-st0{fill:#B3B5B5;}
+	.dcent-st1{fill:#72BFBC;}
+	.dcent-st2{fill:#6D6E70;}
 </style>
 <g>
-	<polygon class="st0" points="32.04,13.43 37.34,10.37 37.34,3.06 32.04,0 32.04,0 	"/>
-	<path class="st1" d="M12.53,45.25V24.69l17.71-10.22V0L0.9,16.94C0.34,17.26,0,17.86,0,18.5v33.88c0,0.03,0.01,0.07,0.01,0.1
+	<polygon class="dcent-st0" points="32.04,13.43 37.34,10.37 37.34,3.06 32.04,0 32.04,0 	"/>
+	<path class="dcent-st1" d="M12.53,45.25V24.69l17.71-10.22V0L0.9,16.94C0.34,17.26,0,17.86,0,18.5v33.88c0,0.03,0.01,0.07,0.01,0.1
 		L12.53,45.25z"/>
-	<path class="st2" d="M48.86,46.69L31.14,56.93L13.52,46.75L0.99,53.99l29.25,16.89c0.28,0.16,0.59,0.24,0.9,0.24
+	<path class="dcent-st2" d="M48.86,46.69L31.14,56.93L13.52,46.75L0.99,53.99l29.25,16.89c0.28,0.16,0.59,0.24,0.9,0.24
 		c0.31,0,0.62-0.08,0.9-0.24l29.34-16.94c0.01,0,0.01-0.01,0.02-0.01L48.86,46.69z"/>
 	<g>
-		<path class="st0" d="M61.38,16.94l-11.63-6.71v7.3l-12.5,7.22l12.5,7.21v13.16l12.53,7.23V18.5
+		<path class="dcent-st0" d="M61.38,16.94l-11.63-6.71v7.3l-12.5,7.22l12.5,7.21v13.16l12.53,7.23V18.5
 			C62.27,17.86,61.93,17.26,61.38,16.94z"/>
 	</g>
-	<polygon class="st2" points="24.93,31.85 24.94,46.18 37.1,39.16 37.1,24.83 	"/>
+	<polygon class="dcent-st2" points="24.93,31.85 24.94,46.18 37.1,39.16 37.1,24.83 	"/>
 </g>
 </svg>
 `

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.0.8-alpha.1",
+  "version": "2.0.8-alpha.2",
   "description": "Injected wallets module for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/injected/src/icons/dcent.ts
+++ b/packages/injected/src/icons/dcent.ts
@@ -1,23 +1,22 @@
-export default `
-<svg xmlns="http://www.w3.org/2000/svg" id="구성_요소_171_4" width="100%" height="100%" viewBox="0 0 48 48">
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+export default `<svg xmlns="http://www.w3.org/2000/svg" id="dcent-_171_4" width="100%" height="100%" viewBox="0 0 48 48">
+<svg version="1.1" id="dcent-Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 62.27 71.11" style="enable-background:new 0 0 62.27 71.11;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#B3B5B5;}
-	.st1{fill:#72BFBC;}
-	.st2{fill:#6D6E70;}
+	.dcent-st0{fill:#B3B5B5;}
+	.dcent-st1{fill:#72BFBC;}
+	.dcent-st2{fill:#6D6E70;}
 </style>
 <g>
-	<polygon class="st0" points="32.04,13.43 37.34,10.37 37.34,3.06 32.04,0 32.04,0 	"/>
-	<path class="st1" d="M12.53,45.25V24.69l17.71-10.22V0L0.9,16.94C0.34,17.26,0,17.86,0,18.5v33.88c0,0.03,0.01,0.07,0.01,0.1
+	<polygon class="dcent-st0" points="32.04,13.43 37.34,10.37 37.34,3.06 32.04,0 32.04,0 	"/>
+	<path class="dcent-st1" d="M12.53,45.25V24.69l17.71-10.22V0L0.9,16.94C0.34,17.26,0,17.86,0,18.5v33.88c0,0.03,0.01,0.07,0.01,0.1
 		L12.53,45.25z"/>
-	<path class="st2" d="M48.86,46.69L31.14,56.93L13.52,46.75L0.99,53.99l29.25,16.89c0.28,0.16,0.59,0.24,0.9,0.24
+	<path class="dcent-st2" d="M48.86,46.69L31.14,56.93L13.52,46.75L0.99,53.99l29.25,16.89c0.28,0.16,0.59,0.24,0.9,0.24
 		c0.31,0,0.62-0.08,0.9-0.24l29.34-16.94c0.01,0,0.01-0.01,0.02-0.01L48.86,46.69z"/>
 	<g>
-		<path class="st0" d="M61.38,16.94l-11.63-6.71v7.3l-12.5,7.22l12.5,7.21v13.16l12.53,7.23V18.5
+		<path class="dcent-st0" d="M61.38,16.94l-11.63-6.71v7.3l-12.5,7.22l12.5,7.21v13.16l12.53,7.23V18.5
 			C62.27,17.86,61.93,17.26,61.38,16.94z"/>
 	</g>
-	<polygon class="st2" points="24.93,31.85 24.94,46.18 37.1,39.16 37.1,24.83 	"/>
+	<polygon class="dcent-st2" points="24.93,31.85 24.94,46.18 37.1,39.16 37.1,24.83 	"/>
 </g>
 </svg>
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -2079,7 +2079,7 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.0"
 
-"@web3-onboard/core@^2.2.10-alpha.1", "@web3-onboard/core@^2.2.9":
+"@web3-onboard/core@^2.2.9":
   version "2.2.10"
   resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.2.10.tgz#61dcc912062548db38d67e228637a27c59122080"
   integrity sha512-sQF14OkT+4ibefXPQ7ueZW7DcKbbCzQXZW64FZ+ETEpgKCYjVarqpcMlp5YB4jv49cWWqM8qXRoskaqz01PktQ==
@@ -2103,6 +2103,16 @@
     "@web3-onboard/common" "^2.0.7"
     joi "^17.4.2"
     lodash.uniqby "^4.7.0"
+
+"@web3-onboard/keystone@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/keystone/-/keystone-2.1.0.tgz#21799e814485719586f4a6df615bd276437e8270"
+  integrity sha512-o9jJ37SKEsish6aJwViUY61olXhW6zmB52lf3MH6tiKx4wKriO2zErnAUK4Exw+xf2wyTuqciwtgzAOLQMpPkA==
+  dependencies:
+    "@ethereumjs/tx" "^3.4.0"
+    "@ethersproject/providers" "^5.5.0"
+    "@keystonehq/eth-keyring" "^0.14.0-alpha.10.3"
+    "@web3-onboard/common" "^2.1.0"
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"


### PR DESCRIPTION
### Description
- Modifies the var and classnames in the dcent icons to remove clashes with other icons

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
