### PR TITLE
Fixes walletconnect import issues for some build tools

### DIFF
--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletconnect",
-  "version": "2.0.1",
+  "version": "2.0.1-alpha.1",
   "description": "WalletConnect module for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletconnect",
-  "version": "2.0.1-alpha.1",
+  "version": "2.0.2-alpha.1",
   "description": "WalletConnect module for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -1,12 +1,10 @@
-import { StaticJsonRpcProvider } from '@ethersproject/providers'
+import type { StaticJsonRpcProvider as StaticJsonRpcProviderType } from '@ethersproject/providers'
 
-import {
+import type {
   Chain,
   ProviderAccounts,
   WalletInit,
-  EIP1193Provider,
-  ProviderRpcError,
-  ProviderRpcErrorCode
+  EIP1193Provider
 } from '@web3-onboard/common'
 
 interface WalletConnectOptions {
@@ -25,11 +23,25 @@ function walletConnect(options?: WalletConnectOptions): WalletInit {
       label: 'WalletConnect',
       getIcon: async () => (await import('./icon.js')).default,
       getInterface: async ({ chains, EventEmitter }) => {
+        const { StaticJsonRpcProvider } = await import(
+          '@ethersproject/providers'
+        )
+
+        const { ProviderRpcError, ProviderRpcErrorCode } = await import(
+          '@web3-onboard/common'
+        )
+
         const { default: WalletConnect } = await import('@walletconnect/client')
 
-        const { default: QRCodeModal } = await import(
-          '@walletconnect/qrcode-modal'
-        )
+        // This is a cjs module and therefor depending on build tooling
+        // sometimes it will be nested in the { default } object and
+        // other times it will be the actual import
+        // @ts-ignore - It thinks it is missing properties since it expect it to be nested under default
+        let QRCodeModal: typeof import('@walletconnect/qrcode-modal').default =
+          await import('@walletconnect/qrcode-modal')
+
+        // @ts-ignore - TS thinks that there is no default property on the `QRCodeModal` but sometimes there is
+        QRCodeModal = QRCodeModal.default || QRCodeModal
 
         const { Subject, fromEvent } = await import('rxjs')
         const { takeUntil, take } = await import('rxjs/operators')
@@ -50,7 +62,7 @@ function walletConnect(options?: WalletConnectOptions): WalletInit {
           public removeListener: typeof EventEmitter['removeListener']
 
           private disconnected$: InstanceType<typeof Subject>
-          private providers: Record<string, StaticJsonRpcProvider>
+          private providers: Record<string, StaticJsonRpcProviderType>
 
           constructor({
             connector,


### PR DESCRIPTION
### Description
Per comments on [this PR](https://github.com/blocknative/web3-onboard/pull/1019) there was an issue where, depending on the build tool, `QRCodeModal` would be either nested under default like: `{ default: QRCodeModal }` and other times would be top level when imported. This PR essentially makes it so that it will work in both scenarios. 

**Below you will find some research behind why this may be the case:**

I looked at these two import statements and noticed something.
https://github.com/blocknative/web3-onboard/blob/faee8bd865e7b090b8b6e4df09649d296a3bca23/packages/walletconnect/src/index.ts#L28-L32

Both imports are `default` imports but while `WalletConnect` is defined `QRCodeModal` is undefined.
What I determined is that `@walletconnect/client` has an esm build while `@walletconnect/qrcode-modal` does not. Observe:

<img width="239" alt="image" src="https://user-images.githubusercontent.com/29665732/173249419-b8415828-5ed8-4716-b9b9-3aa3de9a3807.png">

Anyways, I believe this hack will no longer be needed once we upgrade to walletconnect v2.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
