### PR TITLE
[core - v2.2.12-alpha.2] : bug - Add lowercase coercion to chain ids, add Optimism test net mapped to Optimism Icon

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.2.12-alpha.1",
+  "version": "2.2.12-alpha.2",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -44,9 +44,10 @@ export function addChains(chains: Chain[]): void {
   // chains are validated on init
   const action = {
     type: ADD_CHAINS,
-    payload: chains.map(({ namespace = 'evm', ...rest }) => ({
+    payload: chains.map(({ namespace = 'evm', id, ...rest }) => ({
       ...rest,
-      namespace
+      namespace,
+      id : id.toLowerCase()
     }))
   }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -81,6 +81,7 @@ export const chainIdToLabel: Record<string, string> = {
   '0x89': 'Polygon',
   '0xfa': 'Fantom',
   '0xa': 'Optimism',
+  '0x45': 'Optimism Kovan',
   '0xa86a': 'Avalanche',
   '0xa4ec': 'Celo',
   '0x64': 'Gnosis',

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -125,6 +125,10 @@ export const chainStyles: Record<string, ChainStyle> = {
     icon: optimismIcon,
     color: '#FF0420'
   },
+  '0x45': {
+    icon: optimismIcon,
+    color: '#FF0420'
+  },
   '0xa86a': {
     icon: avalancheIcon,
     color: '#E84142'

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@web3-onboard/coinbase": "^2.0.3",
-    "@web3-onboard/core": "^2.2.11",
+    "@web3-onboard/core": "^2.2.12-alpha.1",
     "@web3-onboard/dcent": "^2.0.0",
     "@web3-onboard/fortmatic": "^2.0.2",
     "@web3-onboard/gnosis": "^2.0.1",
@@ -36,6 +36,7 @@
     "@web3-onboard/torus": "^2.0.1",
     "@web3-onboard/trezor": "^2.1.0",
     "@web3-onboard/walletconnect": "^2.0.1",
+    "@web3-onboard/web3auth": "^2.0.0",
     "vconsole": "^3.9.5"
   },
   "license": "MIT",


### PR DESCRIPTION
### Description
Add Optimism test net mapped to Optimism Icon `0x45`
Add lowercase coercion to chain ids on setting of chains in store.
This will handle situations similar to one seen with optimism where the chain Id set was `0xA` while the associated icon was `0xa` causing an issue where the icon couldn't be found and a warning icon was displayed.
![image](https://user-images.githubusercontent.com/24457880/173609677-e56e0927-eecc-4002-bdc5-6b743c2a6ce8.png)


### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
