### PR TITLE
[core-v2.3.0-alpha.1] : Fix - Update types causing build to break

### DIFF
--- a/packages/core/src/views/notify/Notification.svelte
+++ b/packages/core/src/views/notify/Notification.svelte
@@ -13,7 +13,7 @@
   const { device } = configuration
 
   export let notification: Notification
-  export let updateParentOnRemove
+  export let updateParentOnRemove: () => void
 
   let timeoutId: NodeJS.Timeout
 

--- a/packages/core/src/views/notify/StatusIconBadge.svelte
+++ b/packages/core/src/views/notify/StatusIconBadge.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import ChainBadge from './ChainBadge.svelte'
   import { defaultNotifyEventStyles, unrecognizedChainStyle } from '../../utils'
-  import type { NotificationObject, ChainStyle } from '../../types'
+  import type { Notification, ChainStyle } from '../../types'
   export let chainStyles: ChainStyle = unrecognizedChainStyle
-  export let notification: NotificationObject
+  export let notification: Notification
 </script>
 
 <style>


### PR DESCRIPTION
### Description
Forgot to run `yarn type-check` locally before merging
Update types causing build to break

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
