### PR TITLE
[core-v2.3.0-alpha.3, react-v2.2.0-alpha.4, vue-v2.1.0-alpha.3] : Update - Line height and documentation

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -172,7 +172,7 @@ export type Notification = {
   message: string
   autoDismiss: number
   link?: string
-  onclick?: (event: Event) => void
+  onClick?: (event: Event) => void
 }
 
 export type NotificationType = 'pending' | 'success' | 'error' | 'hint'

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.3.0-alpha.2",
+  "version": "2.3.0-alpha.3",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/core/src/views/notify/NotificationContent.svelte
+++ b/packages/core/src/views/notify/NotificationContent.svelte
@@ -56,7 +56,10 @@
       --notify-onboard-primary-100,
       var(--onboard-primary-100, var(--primary-100))
     );
-    line-height: 14px;
+    line-height: var(
+      --notify-onboard-font-size-5,
+      var(--onboard-font-size-5, var(--font-size-5))
+    );
     font-weight: 400;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.2.0-alpha.2",
+  "version": "2.2.0-alpha.3",
   "description": "Collection of React Hooks for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.2.0-alpha.3",
+  "version": "2.2.0-alpha.4",
   "description": "Collection of React Hooks for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",
@@ -23,7 +23,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.3.0-alpha.2",
+    "@web3-onboard/core": "^2.3.0-alpha.3",
     "@web3-onboard/common": "^2.1.2-alpha.2",
     "use-sync-external-store": "1.0.0"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.1.0-alpha.2",
+  "version": "2.1.0-alpha.3",
   "description": "Vue Composable for web3-onboard",
   "module": "dist/index.js",
   "browser": "dist/index.js",
@@ -24,7 +24,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.1.2-alpha.2",
-    "@web3-onboard/core": "^2.3.0-alpha.2",
+    "@web3-onboard/core": "^2.3.0-alpha.3",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
Update - Line height and documentation for notifications
The line height needs to be equal to the font size to be able to handle letters with tails below the line or they will be cut off

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
