### PR TITLE
Fix typeof check for notify in core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.3.2",
+  "version": "2.3.2-alpha.1",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,7 +103,7 @@ function init(options: InitOptions): OnboardAPI {
   }
 
   // update notify
-  if (typeof notify !== undefined) {
+  if (typeof notify !== 'undefined') {
     if ('desktop' in notify || 'mobile' in notify) {
       const error = validateNotifyOptions(notify)
   


### PR DESCRIPTION
### Description
Fixes #1105, a `typeof` check which was evaluating to `true` even when `notify` would be `undefined`.


### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
