### PR TITLE
[core: 2.3.2-alpha.4]: [fix] -  Recommended Injected Wallets

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.3.2-alpha.3",
+  "version": "2.3.2-alpha.4",
   "repository": "blocknative/web3-onboard",
   "scripts": {
     "build": "rollup -c",

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -396,7 +396,7 @@
                   {connectingErrorMessage}
                 />
               </div>
-            {:else if !walletToAutoSelect}
+            {:else}
               <InstallWallet />
             {/if}
           {/if}

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -52,7 +52,7 @@
   let scrollContainer: HTMLElement
 
   let walletToAutoSelect =
-    autoSelect &&
+    autoSelect.label &&
     walletModules.find(
       ({ label }) => label.toLowerCase() === autoSelect.label.toLowerCase()
     )
@@ -209,7 +209,7 @@
       // user rejected account access
       if (code === ProviderRpcErrorCode.ACCOUNT_ACCESS_REJECTED) {
         connectionRejected = true
-        if (autoSelect) {
+        if (walletToAutoSelect) {
           walletToAutoSelect = null
 
           if (autoSelect.disableModals) {
@@ -360,7 +360,7 @@
 
 <svelte:window bind:innerWidth={windowWidth} />
 
-{#if !autoSelect || (autoSelect && !autoSelect.disableModals)}
+{#if !autoSelect.disableModals}
   <Modal {close}>
     <div class="container relative flex">
       {#if windowWidth >= 809}
@@ -396,7 +396,7 @@
                   {connectingErrorMessage}
                 />
               </div>
-            {:else if !autoSelect}
+            {:else if !walletToAutoSelect}
               <InstallWallet />
             {/if}
           {/if}


### PR DESCRIPTION
### Description
When only the injected wallets module is used and the user has no injected wallets installed, Onboard was no longer displaying the links included in the `reccomendedInjectedWallets` parameter of the `appMetadata` object. This was due to checks not being updated for `autoSelect` now being an object that is always set.

This PR updates all checks for the `autoSelect` parameter which fixes this issue.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
