### PR TITLE
[injected-v2.0.13-alpha.1] : fix - Liquality wallet injection update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-onboard-monorepo",
-  "version": "2.0.13-alpha.1",
+  "version": "2.3.0",
   "private": true,
   "workspaces": [
     "./packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-onboard-monorepo",
-  "version": "2.3.0",
+  "version": "2.0.13-alpha.1",
   "private": true,
   "workspaces": [
     "./packages/*"

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.0.12",
+  "version": "2.0.13-alpha.1",
   "description": "Injected wallets module for web3-onboard",
   "repository": "blocknative/web3-onboard",
   "module": "dist/index.js",

--- a/packages/injected/src/wallets.ts
+++ b/packages/injected/src/wallets.ts
@@ -319,13 +319,18 @@ const imtoken: InjectedWalletModule = {
 
 const liquality: InjectedWalletModule = {
   label: ProviderLabel.Liquality,
-  injectedNamespace: InjectedNameSpace.Arbitrum,
+  injectedNamespace: InjectedNameSpace.Ethereum,
   checkProviderIdentity: ({ provider }) =>
     !!provider && !!provider[ProviderIdentityFlag.Liquality],
   getIcon: async () => (await import('./icons/liquality.js')).default,
   getInterface: async () => {
-    const provider = window[InjectedNameSpace.Arbitrum]
+    const provider = createEIP1193Provider(window.ethereum, {
+      wallet_switchEthereumChain: UNSUPPORTED_METHOD,
+      eth_selectAccounts: UNSUPPORTED_METHOD
+    })
+
     provider.removeListener = (event, func) => {}
+
     return { provider }
   },
   platforms: ['desktop']


### PR DESCRIPTION
### Description
For some strange reason, the liquality wallet was being constrained to the arbitrum namespace. As a result, web3 onboard is not able to connect to liquality except for arbitrum.

Liquality supports regular `window.ethereum` with EIP1993.

This PR fixes this by using `window.ethereum` as injection namespace

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] This PR passes the Circle CI checks
