### PR TITLE
[1.38.4] : Fix CI with Node version bump

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
   deploy_prod:
     docker:
       - image: cimg/node:12.13.1-browser
-      user: root
+        user: root
     steps:
       - checkout
       - run: sudo apt update && sudo apt install awscli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,10 @@ jobs:
   deploy_prod:
     docker:
       - image: cimg/node:12.13.1-browser
-        user: root
+      user: root
     steps:
       - checkout
+      - run: sudo apt update && sudo apt install awscli
       - run: yarn
       - run: yarn build
       - run: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > .npmrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cimg/node:12.13.1-browser
+      - image: circleci/node:12.13.1-browsers
     steps:
       - checkout
       - restore_cache:
@@ -19,9 +19,11 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
   deploy_prod:
     docker:
-      - image: cimg/node:12.13.1-browser
+      - image: circleci/node:12.13.1-browsers
+        user: root
     steps:
       - checkout
+      - run: sudo apt update && sudo apt install awscli
       - run: yarn
       - run: yarn build
       - run: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > .npmrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cimg/node:12.13.1-browser
+      - image: circleci/node:12-browsers
     steps:
       - checkout
       - restore_cache:
@@ -19,7 +19,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
   deploy_prod:
     docker:
-      - image: cimg/node:12.13.1-browser
+      - image: circleci/node:12-browsers
         user: root
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:12-browsers
+      - image: cimg/node:12.13.1-browser
     steps:
       - checkout
       - restore_cache:
@@ -19,11 +19,9 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
   deploy_prod:
     docker:
-      - image: circleci/node:12-browsers
-        user: root
+      - image: cimg/node:12.13.1-browser
     steps:
       - checkout
-      - run: sudo apt update && sudo apt install awscli
       - run: yarn
       - run: yarn build
       - run: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > .npmrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
   deploy_prod:
     docker:
       - image: cimg/node:12.13.1-browser
+        user: root
     steps:
       - checkout
       - run: yarn


### PR DESCRIPTION
### Description
Previous node version defined for Docker Image is unavailable, bumping to 12.13.1

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
