### PR TITLE
[core-v2.4.0-alpha.5, react-v2.2.3-alpha.3, vue v2.1.3-alpha.3] : Feature - Update balances on success notification

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.4.0-alpha.4",
+  "version": "2.4.0-alpha.5",
   "repository": "blocknative/web3-onboard",
   "scripts": {
     "build": "rollup -c",

--- a/packages/core/src/updateBalances.ts
+++ b/packages/core/src/updateBalances.ts
@@ -4,7 +4,6 @@ import { updateAllWallets } from './store/actions'
 
 async function updateBalances(addresses?: string[]): Promise<void> {
   const { wallets, chains } = state.get()
-
   const updatedWallets = await Promise.all(
     wallets.map(async wallet => {
       const chain = chains.find(({ id }) => id === wallet.chains[0].id)
@@ -13,12 +12,16 @@ async function updateBalances(addresses?: string[]): Promise<void> {
         wallet.accounts.map(async account => {
           // if no provided addresses, we want to update all balances
           // otherwise check if address is in addresses array
-          if (!addresses || addresses.includes(account.address)) {
+          if (
+            !addresses ||
+            addresses.some(
+              address => address.toLowerCase() === account.address.toLowerCase()
+            )
+          ) {
             const updatedBalance = await getBalance(account.address, chain)
 
             return { ...account, balance: updatedBalance }
           }
-
           return account
         })
       )

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.2.3-alpha.2",
+  "version": "2.2.3-alpha.3",
   "description": "Collection of React Hooks for web3-onboard",
   "repository": "blocknative/web3-onboard",
   "module": "dist/index.js",
@@ -24,7 +24,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.4.0-alpha.4",
+    "@web3-onboard/core": "^2.4.0-alpha.5",
     "@web3-onboard/common": "^2.1.4",
     "use-sync-external-store": "1.0.0"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.1.3-alpha.2",
+  "version": "2.1.3-alpha.3",
   "description": "Vue Composable for web3-onboard",
   "repository": "blocknative/web3-onboard",
   "module": "dist/index.js",
@@ -25,7 +25,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.1.4",
-    "@web3-onboard/core": "^2.4.0-alpha.4",
+    "@web3-onboard/core": "^2.4.0-alpha.5",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
This PR adds functionality to update Balances of connected wallets who might be the sender(`transaction.to`) or receiver(`transaction.from`) or both if both are connected to onboard. This only occurs on delivery of a notification with a type of `success`.
Also added is functionality to coerce the case to lower of the compared addresses in the `updateBalance` function

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
