### PR TITLE
[core-v2.4.0-alpha.8] : Enhancement - Add --onboard-modal-color

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -760,6 +760,10 @@ The Onboard styles can customized via [CSS variables](https://developer.mozilla.
   --onboard-wallet-button-box-shadow
   --onboard-wallet-app-icon-border-color
 
+  /* CUSTOMIZE THE SHARED MODAL */
+  --onboard-modal-background
+  --onboard-modal-color
+
   /* CUSTOMIZE THE CONNECT MODAL */
   --onboard-modal-border-radius
   --onboard-modal-backdrop

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.4.0-alpha.7",
+  "version": "2.4.0-alpha.8",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/views/shared/Modal.svelte
+++ b/packages/core/src/views/shared/Modal.svelte
@@ -90,6 +90,7 @@
     border-radius: var(--onboard-modal-border-radius, var(--border-radius-1));
     overflow-y: auto;
     background: var(--onboard-modal-background, white);
+    color: var(--onboard-modal-color, initial);
   }
 
   @media all and (max-width: 520px) {

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@web3-onboard/coinbase": "^2.0.7",
-    "@web3-onboard/core": "^2.4.0-alpha.7",
+    "@web3-onboard/core": "^2.4.0-alpha.8",
     "@web3-onboard/dcent": "^2.0.4",
     "@web3-onboard/fortmatic": "^2.0.6",
     "@web3-onboard/gnosis": "^2.0.5",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -59,7 +59,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.4.0-alpha.7",
+    "@web3-onboard/core": "^2.4.0-alpha.8",
     "@web3-onboard/common": "^2.1.4",
     "use-sync-external-store": "1.0.0"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -60,7 +60,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.1.4",
-    "@web3-onboard/core": "^2.4.0-alpha.7",
+    "@web3-onboard/core": "^2.4.0-alpha.8",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
Adds `--onboard-modal-color` (to compliment `--onboard-modal-background`).

Maintains the current default color `initial` (via `all: initial` on `<onboard-v2/>`)

Needed to change default text color for modals such as:
![image](https://user-images.githubusercontent.com/55021052/178110589-76e17bbf-7bdd-4d80-9b12-5fd508924f24.png)

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] This PR passes the Circle CI checks
