### PR TITLE
[common:2.1.6-alpha.1] [keepkey:2.1.6-alpha.1] - Better Error Messages

### DIFF
--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/coinbase",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "description": "Coinbase SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.0.5",
-    "@web3-onboard/common": "^2.1.5"
+    "@web3-onboard/common": "^2.1.6-alpha.1"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/common",
-  "version": "2.1.5",
+  "version": "2.1.6-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/common/src/elements/TableHeader.svelte
+++ b/packages/common/src/elements/TableHeader.svelte
@@ -80,10 +80,7 @@
   input[type='checkbox'] {
     -webkit-appearance: none;
     width: auto;
-    background: var(
-      --account-select-white,
-      var(--onboard-white, var(--white))
-    );
+    background: var(--account-select-white, var(--onboard-white, var(--white)));
     border: 1px solid
       var(--account-select-gray-300, var(--onboard-gray-300, var(--gray-300)));
     padding: 0.5em;
@@ -144,6 +141,9 @@
       --account-select-font-family-light,
       var(--font-family-light)
     );
+    font-size: var(--account-select-font-size-7, var(--font-size-7));
+    max-width: 15rem;
+    line-height: 1;
   }
 
   .table-controls {

--- a/packages/common/src/views/AccountSelect.svelte
+++ b/packages/common/src/views/AccountSelect.svelte
@@ -67,7 +67,17 @@
       loadingAccounts = false
     } catch (err) {
       const { message } = err as { message: string }
-      errorFromScan = message || 'There was an error scanning for accounts'
+
+      if (
+        typeof message === 'string' &&
+        message.includes('could not detect network')
+      ) {
+        errorFromScan =
+          'There was an error detecting connected network from RPC endpoint'
+      } else {
+        errorFromScan = message || 'There was an error scanning for accounts'
+      }
+
       loadingAccounts = false
     }
   }
@@ -397,10 +407,7 @@
     right: 0.2rem;
     width: 2.5rem;
     height: 2.5rem;
-    background: var(
-      --account-select-white,
-      var(--onboard-white, var(--white))
-    );
+    background: var(--account-select-white, var(--onboard-white, var(--white)));
     border-radius: 1rem;
   }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.5.0-alpha.1",
+  "version": "2.5.0-alpha.2",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -78,7 +78,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "bignumber.js": "^9.0.0",
     "bnc-sdk": "^4.4.1",
     "bowser": "^2.11.0",

--- a/packages/dcent/package.json
+++ b/packages/dcent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/dcent",
-  "version": "2.0.5",
+  "version": "2.0.6-alpha.1",
   "description": "D'CENT wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -54,7 +54,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "@ethereumjs/common": "^2.6.1",
     "@ethereumjs/tx": "^3.4.0",
     "@ethersproject/providers": "^5.5.0",

--- a/packages/fortmatic/package.json
+++ b/packages/fortmatic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/fortmatic",
-  "version": "2.0.7",
+  "version": "2.0.8-alpha.1",
   "description": "Fortmatic wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -57,7 +57,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "fortmatic": "^2.2.1"
   }
 }

--- a/packages/gnosis/package.json
+++ b/packages/gnosis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/gnosis",
-  "version": "2.0.6",
+  "version": "2.0.7-alpha.1",
   "description": "Gnosis Safe module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -59,6 +59,6 @@
   "dependencies": {
     "@gnosis.pm/safe-apps-provider": "^0.9.2",
     "@gnosis.pm/safe-apps-sdk": "^6.1.1",
-    "@web3-onboard/common": "^2.1.5"
+    "@web3-onboard/common": "^2.1.6-alpha.1"
   }
 }

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.0.14-alpha.1",
+  "version": "2.0.14-alpha.2",
   "description": "Injected wallet module for connecting browser extension and mobile wallets to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,7 +62,7 @@
     "window": "^4.2.7"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "joi": "^17.4.2",
     "lodash.uniqby": "^4.7.0"
   }

--- a/packages/keepkey/package.json
+++ b/packages/keepkey/package.json
@@ -63,7 +63,7 @@
     "@ethersproject/providers": "^5.5.0",
     "@shapeshiftoss/hdwallet-core": "^1.15.2",
     "@shapeshiftoss/hdwallet-keepkey-webusb": "^1.15.2",
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "ethereumjs-util": "^7.1.3"
   }
 }

--- a/packages/keepkey/package.json
+++ b/packages/keepkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/keepkey",
-  "version": "2.1.5",
+  "version": "2.1.6-alpha.1",
   "description": "KeepKey hardware wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/keepkey/src/index.ts
+++ b/packages/keepkey/src/index.ts
@@ -167,37 +167,43 @@ function keepkey(): WalletInit {
           asset: Asset
           provider: StaticJsonRpcProvider
         }) => {
-          let index = getAccountIdx(derivationPath)
-          let zeroBalanceAccounts = 0
-          const accounts = []
+          try {
+            let index = getAccountIdx(derivationPath)
+            let zeroBalanceAccounts = 0
+            const accounts = []
 
-          // Iterates until a 0 balance account is found
-          // Then adds 4 more 0 balance accounts to the array
-          while (zeroBalanceAccounts < 5) {
-            const acc = await getAccount({
-              accountIdx: index,
-              provider,
-              asset
-            })
+            // Iterates until a 0 balance account is found
+            // Then adds 4 more 0 balance accounts to the array
+            while (zeroBalanceAccounts < 5) {
+              const acc = await getAccount({
+                accountIdx: index,
+                provider,
+                asset
+              })
 
-            if (
-              acc &&
-              acc.balance &&
-              acc.balance.value &&
-              acc.balance.value.isZero()
-            ) {
-              zeroBalanceAccounts++
-              accounts.push(acc)
-            } else {
-              accounts.push(acc)
-              // Reset the number of 0 balance accounts
-              zeroBalanceAccounts = 0
+              if (
+                acc &&
+                acc.balance &&
+                acc.balance.value &&
+                acc.balance.value.isZero()
+              ) {
+                zeroBalanceAccounts++
+                accounts.push(acc)
+              } else {
+                accounts.push(acc)
+                // Reset the number of 0 balance accounts
+                zeroBalanceAccounts = 0
+              }
+
+              index++
             }
 
-            index++
+            return accounts
+          } catch (error) {
+            throw new Error(
+              (error as { message: { message: string } }).message.message
+            )
           }
-
-          return accounts
         }
         let ethersProvider: StaticJsonRpcProvider
         const scanAccounts = async ({

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/keystone",
-  "version": "2.1.6",
+  "version": "2.1.7-alpha.1",
   "description": "Keystone hardware wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -57,6 +57,6 @@
     "@ethereumjs/tx": "^3.4.0",
     "@ethersproject/providers": "^5.5.0",
     "@keystonehq/eth-keyring": "^0.14.0-alpha.10.3",
-    "@web3-onboard/common": "^2.1.5"
+    "@web3-onboard/common": "^2.1.6-alpha.1"
   }
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/ledger",
-  "version": "2.1.5",
+  "version": "2.1.6-alpha.1",
   "description": "Ledger hardare wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -63,7 +63,7 @@
     "@ledgerhq/hw-transport-u2f": "^5.36.0-deprecated",
     "@ledgerhq/hw-transport-webusb": "^6.19.0",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "buffer": "^6.0.3",
     "ethereumjs-util": "^7.1.3"
   }

--- a/packages/magic/package.json
+++ b/packages/magic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/magic",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "description": "Magic SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -78,7 +78,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "joi": "^17.4.2",
     "magic-sdk": "^8.1.0",
     "rxjs": "^7.5.2"

--- a/packages/mew/package.json
+++ b/packages/mew/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/mew",
-  "version": "2.0.5",
+  "version": "2.0.6-alpha.1",
   "description": "MEW (My Ether Wallet) SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -59,7 +59,7 @@
     "@myetherwallet/mewconnect-web-client": "^2.2.0-beta.14"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "rxjs": "^7.5.2"
   }
 }

--- a/packages/portis/package.json
+++ b/packages/portis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/portis",
-  "version": "2.0.5",
+  "version": "2.0.6-alpha.1",
   "description": "Portis SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "@portis/web3": "^4.0.6",
-    "@web3-onboard/common": "^2.1.5"
+    "@web3-onboard/common": "^2.1.6-alpha.1"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.2.4-alpha.1",
+  "version": "2.2.4-alpha.2",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -59,8 +59,8 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.4.1-alpha.1",
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/core": "^2.4.1-alpha.2",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "use-sync-external-store": "1.0.0"
   },
   "peerDependencies": {

--- a/packages/torus/package.json
+++ b/packages/torus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/torus",
-  "version": "2.0.6",
+  "version": "2.0.7-alpha.1",
   "description": "Torus SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "@toruslabs/torus-embed": "^1.18.3",
-    "@web3-onboard/common": "^2.1.5"
+    "@web3-onboard/common": "^2.1.6-alpha.1"
   }
 }

--- a/packages/trezor/package.json
+++ b/packages/trezor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/trezor",
-  "version": "2.1.5",
+  "version": "2.1.6-alpha.1",
   "description": "Trezor hardware wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -58,7 +58,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^3.4.0",
     "@ethersproject/providers": "^5.5.0",
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "buffer": "^6.0.3",
     "eth-crypto": "^2.1.0",
     "ethereumjs-util": "^7.1.3",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.1.4-alpha.1",
+  "version": "2.1.4-alpha.2",
   "description": "A collection of Vue Composables for integrating Web3-Onboard in to a Vue or Nuxt project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -59,8 +59,8 @@
   "dependencies": {
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
-    "@web3-onboard/common": "^2.1.5",
-    "@web3-onboard/core": "^2.4.1-alpha.1",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
+    "@web3-onboard/core": "^2.4.1-alpha.2",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletconnect",
-  "version": "2.0.6",
+  "version": "2.0.7-alpha.1",
   "description": "WalletConnect SDK module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -59,7 +59,7 @@
     "@ethersproject/providers": "^5.5.0",
     "@walletconnect/client": "^1.7.1",
     "@walletconnect/qrcode-modal": "^1.7.1",
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "rxjs": "^7.5.2"
   }
 }

--- a/packages/walletlink/package.json
+++ b/packages/walletlink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletlink",
-  "version": "2.0.5",
+  "version": "2.0.6-alpha.1",
   "description": "(DEPRECATED. Use @web3-onboard/coinbase instead) WalletLink SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -56,7 +56,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "walletlink": "^2.5.0"
   }
 }

--- a/packages/web3auth/package.json
+++ b/packages/web3auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/web3auth",
-  "version": "2.0.4",
+  "version": "2.0.5-alpha.1",
   "description": "Web3Auth SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -56,7 +56,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.5",
+    "@web3-onboard/common": "^2.1.6-alpha.1",
     "@web3auth/web3auth": "^1.0.0"
   }
 }


### PR DESCRIPTION
### Description
This PR includes:
- Style modifications to the rendered error message in the account select modal for hardware wallets
- Modifies the keepkey pin entry error to render a string message
- Formats the error returned from rpc for when the network cannot be detected

<img width="830" alt="Screen Shot 2022-07-15 at 10 35 13 am" src="https://user-images.githubusercontent.com/29873495/179141348-a7151132-5d02-4f82-b166-493d70afb4ae.png">

Closes #982 

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
