### PR TITLE
[core: 2.6.0-alpha.2] - [fix] - Autoselect  with disabled modals resolve

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.6.0-alpha.1",
+  "version": "2.6.0-alpha.2",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -51,12 +51,6 @@
   let windowWidth: number
   let scrollContainer: HTMLElement
 
-  let walletToAutoSelect =
-    autoSelect.label &&
-    walletModules.find(
-      ({ label }) => label.toLowerCase() === autoSelect.label.toLowerCase()
-    )
-
   const modalStep$ = new BehaviorSubject<keyof i18n['connect']>(
     'selectingWallet'
   )
@@ -209,13 +203,13 @@
       // user rejected account access
       if (code === ProviderRpcErrorCode.ACCOUNT_ACCESS_REJECTED) {
         connectionRejected = true
-        if (walletToAutoSelect) {
-          walletToAutoSelect = null
 
-          if (autoSelect.disableModals) {
-            connectWallet$.next({ inProgress: false })
-          }
+        if (autoSelect.disableModals) {
+          connectWallet$.next({ inProgress: false })
+        } else if (autoSelect.label) {
+          autoSelect.label = ''
         }
+
         return
       }
 
@@ -263,8 +257,17 @@
   modalStep$.pipe(takeUntil(onDestroy$)).subscribe(step => {
     switch (step) {
       case 'selectingWallet': {
-        if (walletToAutoSelect) {
-          autoSelectWallet(walletToAutoSelect)
+        if (autoSelect.label) {
+          const walletToAutoSelect = walletModules.find(
+            ({ label }) =>
+              label.toLowerCase() === autoSelect.label.toLowerCase()
+          )
+
+          if (walletToAutoSelect) {
+            autoSelectWallet(walletToAutoSelect)
+          } else if (autoSelect.disableModals) {
+            connectWallet$.next({ inProgress: false })
+          }
         } else {
           loadWalletsForSelection()
         }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.6.0-alpha.1",
+    "@web3-onboard/core": "^2.6.0-alpha.2",
     "@web3-onboard/common": "^2.1.7-alpha.1",
     "use-sync-external-store": "1.0.0"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -63,7 +63,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.1.7-alpha.1",
-    "@web3-onboard/core": "^2.6.0-alpha.1",
+    "@web3-onboard/core": "^2.6.0-alpha.2",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
This PR fixes an issue where the call to `connectWallet` would not resolve or reject if called with the `autoSelect` parameter for a wallet that is no longer available.

Fixes #1153 

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
