### PR TITLE
Fix trezor nonce

### DIFF
--- a/packages/trezor/package.json
+++ b/packages/trezor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/trezor",
-  "version": "2.1.7-alpha.1",
+  "version": "2.1.7-alpha.2",
   "description": "Trezor hardware wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/trezor/src/index.ts
+++ b/packages/trezor/src/index.ts
@@ -284,7 +284,7 @@ function trezor(options: TrezorOptions): WalletInit {
               maxFeePerGas: transactionData.maxFeePerGas!,
               maxPriorityFeePerGas: transactionData.maxPriorityFeePerGas!,
               nonce: transactionData.nonce!,
-              chainId: parseInt(currentChain.id),
+              chainId: Number(currentChain.id),
               data: transactionData.hasOwnProperty('data')
                 ? transactionData.data
                 : ''
@@ -296,7 +296,7 @@ function trezor(options: TrezorOptions): WalletInit {
             gasPrice: transactionData.gasPrice!,
             gasLimit: gasLimit!,
             nonce: transactionData.nonce!,
-            chainId: parseInt(currentChain.id),
+            chainId: Number(currentChain.id),
             data: transactionData.hasOwnProperty('data')
               ? transactionData.data
               : ''
@@ -372,7 +372,7 @@ function trezor(options: TrezorOptions): WalletInit {
           )
 
           const chainId = currentChain.hasOwnProperty('id')
-            ? Number.parseInt(currentChain.id)
+            ? Number(currentChain.id)
             : 1
           const common = await getCommon({ customNetwork, chainId })
 
@@ -395,7 +395,7 @@ function trezor(options: TrezorOptions): WalletInit {
 
           // EIP155 support. check/recalc signature v value.
           const rv = parseInt(v, 16)
-          let cv = parseInt(currentChain.id) * 2 + 35
+          let cv = Number(currentChain.id) * 2 + 35
           if (rv !== cv && (rv & cv) !== rv) {
             cv += 1 // add signature v bit.
           }
@@ -486,7 +486,7 @@ function trezor(options: TrezorOptions): WalletInit {
               ? [accounts[0].address]
               : [],
           eth_chainId: async () =>
-            currentChain.hasOwnProperty('id') ? currentChain.id : '',
+            currentChain.hasOwnProperty('id') ? String(currentChain.id) : '',
           eth_signTransaction: async ({ params: [transactionObject] }) =>
             signTransaction(transactionObject),
           eth_sendTransaction: async ({ baseRequest, params }) => {

--- a/packages/trezor/src/index.ts
+++ b/packages/trezor/src/index.ts
@@ -353,6 +353,15 @@ function trezor(options: TrezorOptions): WalletInit {
           ) {
             populatedTransaction.nonce = populatedTransaction.nonce.toString(16)
           }
+          if (
+            populatedTransaction.hasOwnProperty('nonce') &&
+            typeof populatedTransaction.nonce === 'string'
+          ) {
+            // Adds "0x" to a given `String` if it does not already start with "0x".
+            populatedTransaction.nonce = ethUtil.addHexPrefix(
+              populatedTransaction.nonce
+            )
+          }
 
           const updateBigNumberFields =
             bigNumberFieldsToStrings(populatedTransaction)


### PR DESCRIPTION
### Description
This PR resolves an issue were we pass a nonce missing 0x prefix. 

To get the transaction signed on line 404 in [trezor/src/index.ts](https://github.com/blocknative/web3-onboard/blob/v2-web3-onboard-develop/packages/trezor/src/index.ts#L395) we call `Transaction.fromTxData`. The `Transaction` class is coming from `@ethereumjs/tx`.
When calling `fromTxData` that package will instantiate a class extending their `BaseTransaction`. The `BaseTransaction` constructor will try to convert the `nonce` to first a `buffer` and then `BigInt` [see here](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L101)  . To convert the string to a buffer they rely on `toBuffer` from `@ethereumjs/util`, this method will throw if passed a string not prefixed with `0x` [See here]( https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/src/bytes.ts#L149)

Using an infura provider I consistently got a nonce without `0x`. I also fixed some minor type errors.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
