### PR TITLE
[gas:2.0.0-alpha.2] [core:2.6.0-alpha.7] - [enhancement] - Modify Gas API Response

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.6.0-alpha.6",
+  "version": "2.6.0-alpha.7",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -68,7 +68,7 @@
     "@types/lodash.partition": "^4.6.6",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
-    "@web3-onboard/gas": "^2.0.0-alpha.1",
+    "@web3-onboard/gas": "^2.0.0-alpha.2",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-svelte3": "^3.2.1",

--- a/packages/gas/package.json
+++ b/packages/gas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/gas",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Gas",
   "keywords": [
     "gas"

--- a/packages/gas/src/get.ts
+++ b/packages/gas/src/get.ts
@@ -1,13 +1,10 @@
 import { firstValueFrom, zip } from 'rxjs'
-import { map } from 'rxjs/operators'
 import { ajax } from 'rxjs/ajax'
 import { getRequestUrl } from './utils'
 import { RequestOptions, ChainId, GasPlatformResponse } from './types'
 import { validateRequest } from './validation'
 
-function get(
-  options: RequestOptions
-): Promise<Record<ChainId, GasPlatformResponse>> {
+function get(options: RequestOptions): Promise<GasPlatformResponse[]> {
   const invalid = validateRequest(options)
 
   if (invalid) {
@@ -25,14 +22,6 @@ function get(
     zip(
       requestUrls.map(({ url, headers }) =>
         ajax.getJSON<GasPlatformResponse>(url, headers)
-      )
-    ).pipe(
-      // reduce to mapping of chainId -> gas data
-      map(data =>
-        chains.reduce((acc, chainId, index) => {
-          acc[chainId] = data[index]
-          return acc
-        }, {})
       )
     )
   )

--- a/packages/gas/src/stream.ts
+++ b/packages/gas/src/stream.ts
@@ -1,13 +1,11 @@
 import { Observable, timer, zip } from 'rxjs'
-import { switchMap, map } from 'rxjs/operators'
+import { switchMap } from 'rxjs/operators'
 import { ajax } from 'rxjs/ajax'
 import { getRequestUrl } from './utils'
-import { StreamOptions, ChainId, GasPlatformResponse } from './types'
+import { StreamOptions, GasPlatformResponse } from './types'
 import { validateRequest } from './validation'
 
-function stream(
-  options: StreamOptions
-): Observable<Record<ChainId, GasPlatformResponse>> {
+function stream(options: StreamOptions): Observable<GasPlatformResponse[]> {
   const invalid = validateRequest(options)
 
   if (invalid) {
@@ -29,13 +27,6 @@ function stream(
           ajax.getJSON<GasPlatformResponse>(url, headers)
         )
       )
-    ),
-    // reduce to mapping of chainId -> gas data
-    map(data =>
-      chains.reduce((acc, chainId, index) => {
-        acc[chainId] = data[index]
-        return acc
-      }, {})
     )
   )
 }


### PR DESCRIPTION
### Description
After working with the Gas API for an upcoming feature, I realised that it is more convenient if the responses came back as an array of responses rather than a mapping of chainId -> response. This PR modifies the API to do that and increments versions.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
