### PR TITLE
[common-v2.1.7-alpha.5, core-v2.6.0-alpha.8, react-v2.2.5-alpha.7]fix: weifix

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/common",
-  "version": "2.1.7-alpha.5",
+  "version": "2.1.7-alpha.6",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/common",
-  "version": "2.1.7-alpha.4",
+  "version": "2.1.7-alpha.5",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/common/src/elements/AddressTable.svelte
+++ b/packages/common/src/elements/AddressTable.svelte
@@ -120,7 +120,7 @@
             >
             <td>{account.derivationPath}</td>
             <td class="asset-td"
-              >{weiToEth(account.balance.value)}
+              >{weiToEth(account.balance.value.toString())}
               {account.balance.asset}</td
             >
           </tr>

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,7 +1,7 @@
 import type { ConnectionInfo } from 'ethers/lib/utils'
 import type EventEmitter from 'eventemitter3'
 import type { TypedData as EIP712TypedData } from 'eip-712'
-import type BigNumber from 'bignumber.js'
+import type { ethers } from 'ethers'
 export type { TypedData as EIP712TypedData } from 'eip-712'
 
 /**
@@ -116,7 +116,7 @@ export type Account = {
   derivationPath: DerivationPath
   balance: {
     asset: Asset['label']
-    value: BigNumber
+    value: ethers.BigNumber
   }
 }
 
@@ -232,7 +232,7 @@ export interface WalletModule {
 export type GetInterfaceHelpers = {
   chains: Chain[]
   appMetadata: AppMetadata | null
-  BigNumber: typeof BigNumber
+  BigNumber: typeof ethers.BigNumber
   EventEmitter: typeof EventEmitter
 }
 

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,5 +1,5 @@
-import type BigNumber from 'bignumber.js'
+import BigNumber from 'bignumber.js'
 
-export function weiToEth(wei: BigNumber): string {
-    return wei.div(1e18).toString(10)
+export function weiToEth(wei: string): string {
+   return new BigNumber(wei).div(1e18).toString(10)
 }

--- a/packages/common/src/validation.ts
+++ b/packages/common/src/validation.ts
@@ -9,9 +9,9 @@ const basePaths = Joi.array().items(basePath)
 
 const chain = Joi.object({
   namespace: Joi.string(),
-  id: Joi.alternatives()
-        .try(Joi.string().pattern(/^0x[0-9a-fA-F]+$/), 
-        Joi.number().positive()).required,
+  id: Joi.string()
+    .pattern(/^0x[0-9a-fA-F]+$/)
+    .required(),
   rpcUrl: Joi.string().required(),
   label: Joi.string().required(),
   token: Joi.string().required(),

--- a/packages/common/src/views/AccountSelect.svelte
+++ b/packages/common/src/views/AccountSelect.svelte
@@ -60,7 +60,7 @@
       accountsListObject = {
         all: allAccounts,
         filtered: allAccounts.filter(account => {
-          return parseFloat(weiToEth(account.balance.value)) > 0
+          return parseFloat(weiToEth(account.balance.value.toString())) > 0
         })
       }
       loadingAccounts = false

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.6.0-alpha.8",
+  "version": "2.6.0-alpha.9",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -83,7 +83,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7-alpha.5",
+    "@web3-onboard/common": "^2.1.7-alpha.6",
     "bignumber.js": "^9.0.0",
     "bnc-sdk": "^4.4.1",
     "bowser": "^2.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.6.0-alpha.7",
+  "version": "2.6.0-alpha.8",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -83,7 +83,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7-alpha.4",
+    "@web3-onboard/common": "^2.1.7-alpha.5",
     "bignumber.js": "^9.0.0",
     "bnc-sdk": "^4.4.1",
     "bowser": "^2.11.0",

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -350,7 +350,7 @@ export async function getBalance(
     const balanceHex = await provider.request({ method: 'eth_getBalance', params:[address,'latest'] })
     const balanceWei = new BigNumber(parseInt(balanceHex, 16))
     return balanceWei
-      ? { [chain.token || 'eth']: weiToEth(balanceWei) }
+      ? { [chain.token || 'eth']: weiToEth(balanceWei.toString()) }
       : null
   } catch (error) {
     console.error(error)

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -348,9 +348,8 @@ export async function getBalance(
     const wallet = wallets.find(wallet => !!wallet.provider)
     const provider = wallet.provider
     const balanceHex = await provider.request({ method: 'eth_getBalance', params:[address,'latest'] })
-    const balanceWei = new BigNumber(parseInt(balanceHex, 16))
-    return balanceWei
-      ? { [chain.token || 'eth']: weiToEth(balanceWei.toString()) }
+    return balanceHex
+      ? { [chain.token || 'eth']: weiToEth(balanceHex) }
       : null
   } catch (error) {
     console.error(error)

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -22,7 +22,6 @@ import { validEnsChain } from './utils'
 import disconnect from './disconnect'
 import { state } from './store'
 import { getBlocknativeSdk } from './services'
-import BigNumber from 'bignumber.js'
 
 export const ethersProviders: {
   [key: string]: providers.StaticJsonRpcProvider

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -19,7 +19,7 @@
   import Sidebar from './Sidebar.svelte'
   import { configuration } from '../../configuration'
   import { getBlocknativeSdk } from '../../services'
-  import BigNumber from 'bignumber.js'
+  import { BigNumber } from 'ethers'
   import {
     getChainId,
     requestAccounts,

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "devDependencies": {
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@web3-onboard/coinbase": "^2.0.8",
-    "@web3-onboard/core": "^2.6.0-alpha.8",
+    "@web3-onboard/core": "^2.6.0-alpha.9",
     "@web3-onboard/dcent": "^2.0.5",
     "@web3-onboard/fortmatic": "^2.0.6",
     "@web3-onboard/gnosis": "^2.0.5",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@web3-onboard/coinbase": "^2.0.8",
-    "@web3-onboard/core": "^2.6.0-alpha.5",
+    "@web3-onboard/core": "^2.6.0-alpha.8",
     "@web3-onboard/dcent": "^2.0.5",
     "@web3-onboard/fortmatic": "^2.0.6",
     "@web3-onboard/gnosis": "^2.0.5",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.2.5-alpha.6",
+  "version": "2.2.5-alpha.7",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,8 +62,8 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.6.0-alpha.7",
-    "@web3-onboard/common": "^2.1.7-alpha.4",
+    "@web3-onboard/core": "^2.6.0-alpha.8",
+    "@web3-onboard/common": "^2.1.7-alpha.5",
     "use-sync-external-store": "1.0.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,8 +62,8 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.6.0-alpha.8",
-    "@web3-onboard/common": "^2.1.7-alpha.5",
+    "@web3-onboard/core": "^2.6.0-alpha.9",
+    "@web3-onboard/common": "^2.1.7-alpha.6",
     "use-sync-external-store": "1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
<!-- Add a description of the fix or feature here -->
This PR: 
- enforces the weiToETH function to accept only strings from core and common 
- returns ethers.BigNumber for GetInterfaceHelpers used by Ledger

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
