### PR TITLE
common-v2.1.7-alpha.5, core-v2.6.0-alpha.8......]:Fix: bundler-minify-version

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/common",
-  "version": "2.1.7-alpha.4",
+  "version": "2.1.7-alpha.5",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -37,7 +37,7 @@ export default {
       inlineSources: !production
     }),
     production && terser({
-      ecma: 2020,
+      ecma: 2017,
       mangle: { toplevel: true },
       compress: {
         module: true,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.6.0-alpha.7",
+  "version": "2.6.0-alpha.8",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -83,7 +83,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7-alpha.4",
+    "@web3-onboard/common": "^2.1.7-alpha.5",
     "bignumber.js": "^9.0.0",
     "bnc-sdk": "^4.4.1",
     "bowser": "^2.11.0",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -42,7 +42,7 @@ export default {
       dest: 'i18n'
     }),
     production && terser({
-      ecma: 2020,
+      ecma: 2017,
       mangle: { toplevel: true },
       compress: {
         module: true,

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demo",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "devDependencies": {
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@web3-onboard/coinbase": "^2.0.8",
-    "@web3-onboard/core": "^2.6.0-alpha.5",
+    "@web3-onboard/core": "^2.6.0-alpha.8",
     "@web3-onboard/dcent": "^2.0.5",
     "@web3-onboard/fortmatic": "^2.0.6",
     "@web3-onboard/gnosis": "^2.0.5",

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.0.15-alpha.3",
+  "version": "2.0.15-alpha.4",
   "description": "Injected wallet module for connecting browser extension and mobile wallets to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,7 +62,7 @@
     "window": "^4.2.7"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7-alpha.1",
+    "@web3-onboard/common": "^2.1.7-alpha.5",
     "joi": "^17.4.2",
     "lodash.uniqby": "^4.7.0"
   }


### PR DESCRIPTION
### Description
<!-- Add a description of the fix or feature here -->
Downgrades terser minify es version to 2017

Recommended by @Adamj1232 Since the rest of the projects has a JS operator cut off at ES 8 (2017) and the current was causing issues for Beefy
<img width="1103" alt="Screen Shot 2022-08-01 at 9 42 16 AM" src="https://user-images.githubusercontent.com/24457880/182208562-9c3e960c-6be1-47f8-bc5c-9a0f05159e2e.png">


### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] I have run `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
