### PR TITLE
[common-v2.1.8-alpha.1, core-v2.7.0-alpha.3, react-v2.2.6-alpha.2, vue-v2.1.6-alpha.2...]: Fix - Remove Terser from Rollup(minification)

### DIFF
--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/coinbase",
-  "version": "2.0.10",
+  "version": "2.0.11-alpha.1",
   "description": "Coinbase SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -59,6 +59,6 @@
   },
   "dependencies": {
     "@coinbase/wallet-sdk": "^3.0.5",
-    "@web3-onboard/common": "^2.1.7"
+    "@web3-onboard/common": "^2.1.8-alpha.1"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -73,7 +73,6 @@
     "prettier-plugin-svelte": "^2.4.0",
     "rollup": "^2.3.4",
     "rollup-plugin-svelte": "^7.0.0",
-    "rollup-plugin-terser": "^7.0.2",
     "svelte": "^3.42.5",
     "svelte-check": "^2.2.6",
     "svelte-preprocess": "^4.9.4",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/common",
-  "version": "2.1.7",
+  "version": "2.1.8-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/common/rollup.config.js
+++ b/packages/common/rollup.config.js
@@ -4,7 +4,6 @@ import replace from '@rollup/plugin-replace'
 import json from '@rollup/plugin-json'
 import sveltePreprocess from 'svelte-preprocess'
 import typescript from '@rollup/plugin-typescript'
-import { terser } from 'rollup-plugin-terser'
 
 const production = !process.env.ROLLUP_WATCH
 
@@ -12,8 +11,7 @@ export default {
   input: 'src/index.ts',
   output: {
     format: 'esm',
-    dir: 'dist/',
-    sourcemap: true,
+    dir: 'dist/'
   },
   plugins: [
     json(),
@@ -35,18 +33,6 @@ export default {
     typescript({
       sourceMap: !production,
       inlineSources: !production
-    }),
-    production && terser({
-      ecma: 2017,
-      mangle: { toplevel: true },
-      compress: {
-        module: true,
-        toplevel: true,
-        unsafe_arrows: true,
-        drop_console: production,
-        drop_debugger: production
-      },
-      output: { quote_style: 1 }
     })
   ],
   external: ['joi', 'rxjs', 'ethers', '@ethereumjs/common', 'bignumber.js']

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.7.0-alpha.2",
+  "version": "2.7.0-alpha.3",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -82,7 +82,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "bignumber.js": "^9.0.0",
     "bnc-sdk": "^4.4.1",
     "bowser": "^2.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,7 +76,6 @@
     "prettier-plugin-svelte": "^2.4.0",
     "rollup": "^2.3.4",
     "rollup-plugin-svelte": "^7.0.0",
-    "rollup-plugin-terser": "^7.0.2",
     "svelte-check": "^2.2.6",
     "svelte-preprocess": "^4.9.4",
     "tslib": "^2.0.0",

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -5,7 +5,6 @@ import json from '@rollup/plugin-json'
 import sveltePreprocess from 'svelte-preprocess'
 import typescript from '@rollup/plugin-typescript'
 import copy from '@rollup-extras/plugin-copy'
-import { terser } from 'rollup-plugin-terser'
 
 const production = !process.env.ROLLUP_WATCH
 
@@ -14,7 +13,6 @@ export default {
   output: {
     format: 'es',
     dir: 'dist/',
-    sourcemap: true,
   },
   plugins: [
     json(),
@@ -41,18 +39,6 @@ export default {
       src: 'src/i18n/en.json',
       dest: 'i18n'
     }),
-    production && terser({
-      ecma: 2017,
-      mangle: { toplevel: true },
-      compress: {
-        module: true,
-        toplevel: true,
-        unsafe_arrows: true,
-        drop_console: production,
-        drop_debugger: production
-      },
-      output: { quote_style: 1 }
-    })
   ],
   external: [
     '@web3-onboard/common',

--- a/packages/dcent/package.json
+++ b/packages/dcent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/dcent",
-  "version": "2.0.7",
+  "version": "2.0.8-alpha.1",
   "description": "D'CENT wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -56,7 +56,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "@ethereumjs/common": "^2.6.1",
     "@ethereumjs/tx": "^3.4.0",
     "@ethersproject/providers": "^5.5.0",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@web3-onboard/coinbase": "^2.0.10",
-    "@web3-onboard/core": "^2.7.0-alpha.2",
+    "@web3-onboard/core": "^2.7.0-alpha.3",
     "@web3-onboard/dcent": "^2.0.7",
     "@web3-onboard/fortmatic": "^2.0.9",
     "@web3-onboard/gas": "^2.0.0",

--- a/packages/fortmatic/package.json
+++ b/packages/fortmatic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/fortmatic",
-  "version": "2.0.9",
+  "version": "2.0.10-alpha.1",
   "description": "Fortmatic wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -59,7 +59,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "fortmatic": "^2.2.1"
   }
 }

--- a/packages/gnosis/package.json
+++ b/packages/gnosis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/gnosis",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "description": "Gnosis Safe module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -59,6 +59,6 @@
   "dependencies": {
     "@gnosis.pm/safe-apps-provider": "^0.9.2",
     "@gnosis.pm/safe-apps-sdk": "^6.1.1",
-    "@web3-onboard/common": "^2.1.7"
+    "@web3-onboard/common": "^2.1.8-alpha.1"
   }
 }

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.0.15",
+  "version": "2.0.16-alpha.1",
   "description": "Injected wallet module for connecting browser extension and mobile wallets to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,7 +62,7 @@
     "window": "^4.2.7"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "joi": "^17.4.2",
     "lodash.uniqby": "^4.7.0"
   }

--- a/packages/keepkey/package.json
+++ b/packages/keepkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/keepkey",
-  "version": "2.1.7",
+  "version": "2.1.8-alpha.1",
   "description": "KeepKey hardware wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -63,7 +63,7 @@
     "@ethersproject/providers": "^5.5.0",
     "@shapeshiftoss/hdwallet-core": "^1.15.2",
     "@shapeshiftoss/hdwallet-keepkey-webusb": "^1.15.2",
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "ethereumjs-util": "^7.1.3"
   }
 }

--- a/packages/keystone/package.json
+++ b/packages/keystone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/keystone",
-  "version": "2.1.8",
+  "version": "2.1.9-alpha.1",
   "description": "Keystone hardware wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -58,6 +58,6 @@
     "@ethereumjs/tx": "^3.4.0",
     "@ethersproject/providers": "^5.5.0",
     "@keystonehq/eth-keyring": "^0.14.0-alpha.10.3",
-    "@web3-onboard/common": "^2.1.7"
+    "@web3-onboard/common": "^2.1.8-alpha.1"
   }
 }

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/ledger",
-  "version": "2.1.8-alpha.1",
+  "version": "2.1.8-alpha.2",
   "description": "Ledger hardare wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -65,7 +65,7 @@
     "@ledgerhq/hw-transport-u2f": "^5.36.0-deprecated",
     "@ledgerhq/hw-transport-webusb": "^6.19.0",
     "@metamask/eth-sig-util": "^4.0.0",
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "buffer": "^6.0.3",
     "ethereumjs-util": "^7.1.3"
   }

--- a/packages/magic/package.json
+++ b/packages/magic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/magic",
-  "version": "2.0.10",
+  "version": "2.0.11-alpha.1",
   "description": "Magic SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -80,7 +80,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "joi": "^17.4.2",
     "magic-sdk": "^8.1.0",
     "rxjs": "^7.5.2"

--- a/packages/mew/package.json
+++ b/packages/mew/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/mew",
-  "version": "2.0.7",
+  "version": "2.0.8-alpha.1",
   "description": "MEW (My Ether Wallet) SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -59,7 +59,7 @@
     "@myetherwallet/mewconnect-web-client": "^2.2.0-beta.14"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "rxjs": "^7.5.2"
   }
 }

--- a/packages/portis/package.json
+++ b/packages/portis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/portis",
-  "version": "2.0.7",
+  "version": "2.0.8-alpha.1",
   "description": "Portis SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "@portis/web3": "^4.0.6",
-    "@web3-onboard/common": "^2.1.7"
+    "@web3-onboard/common": "^2.1.8-alpha.1"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.2.6-alpha.1",
+  "version": "2.2.6-alpha.2",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,8 +62,8 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.7.0-alpha.1",
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/core": "^2.7.0-alpha.3",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "use-sync-external-store": "1.0.0"
   },
   "peerDependencies": {

--- a/packages/torus/package.json
+++ b/packages/torus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/torus",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "description": "Torus SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "@toruslabs/torus-embed": "^1.18.3",
-    "@web3-onboard/common": "^2.1.7"
+    "@web3-onboard/common": "^2.1.8-alpha.1"
   }
 }

--- a/packages/trezor/package.json
+++ b/packages/trezor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/trezor",
-  "version": "2.1.7",
+  "version": "2.1.8-alpha.1",
   "description": "Trezor hardware wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -60,7 +60,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^3.4.0",
     "@ethersproject/providers": "^5.5.0",
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "buffer": "^6.0.3",
     "eth-crypto": "^2.1.0",
     "ethereumjs-util": "^7.1.3",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.1.6-alpha.1",
+  "version": "2.1.6-alpha.2",
   "description": "A collection of Vue Composables for integrating Web3-Onboard in to a Vue or Nuxt project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,8 +62,8 @@
   "dependencies": {
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
-    "@web3-onboard/common": "^2.1.7",
-    "@web3-onboard/core": "^2.7.0-alpha.1",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
+    "@web3-onboard/core": "^2.7.0-alpha.3",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletconnect",
-  "version": "2.0.8",
+  "version": "2.0.9-alpha.1",
   "description": "WalletConnect SDK module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -61,7 +61,7 @@
     "@ethersproject/providers": "^5.5.0",
     "@walletconnect/client": "^1.7.1",
     "@walletconnect/qrcode-modal": "^1.7.1",
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "rxjs": "^7.5.2"
   }
 }

--- a/packages/walletlink/package.json
+++ b/packages/walletlink/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletlink",
-  "version": "2.0.6",
+  "version": "2.0.7-alpha.1",
   "description": "(DEPRECATED. Use @web3-onboard/coinbase instead) WalletLink SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -58,7 +58,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.6",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "walletlink": "^2.5.0"
   }
 }

--- a/packages/web3auth/package.json
+++ b/packages/web3auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/web3auth",
-  "version": "2.0.6",
+  "version": "2.0.7-alpha.1",
   "description": "Web3Auth SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -56,7 +56,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/common": "^2.1.7",
+    "@web3-onboard/common": "^2.1.8-alpha.1",
     "@web3auth/web3auth": "^1.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,13 +14,6 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.10.4":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
-  integrity sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==
-  dependencies:
-    "@babel/highlight" "^7.18.6"
-
 "@babel/code-frame@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.16.7.tgz#44416b6bd7624b998f5b1af5d470856c40138789"
@@ -120,11 +113,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
   integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
-"@babel/helper-validator-identifier@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz#9c97e30d31b2b8c72a1d08984f2ca9b574d7a076"
-  integrity sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==
-
 "@babel/helper-validator-option@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
@@ -136,15 +124,6 @@
   integrity sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==
   dependencies:
     "@babel/helper-validator-identifier" "^7.16.7"
-    chalk "^2.0.0"
-    js-tokens "^4.0.0"
-
-"@babel/highlight@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.18.6.tgz#81158601e93e2563795adcbfbdf5d64be3f2ecdf"
-  integrity sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.18.6"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
@@ -838,46 +817,6 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
-
-"@jridgewell/gen-mapping@^0.3.0":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
-  integrity sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==
-  dependencies:
-    "@jridgewell/set-array" "^1.0.1"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
-    "@jridgewell/trace-mapping" "^0.3.9"
-
-"@jridgewell/resolve-uri@^3.0.3":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
-  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
-
-"@jridgewell/set-array@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
-  integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
-
-"@jridgewell/source-map@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/source-map/-/source-map-0.3.2.tgz#f45351aaed4527a298512ec72f81040c998580fb"
-  integrity sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==
-  dependencies:
-    "@jridgewell/gen-mapping" "^0.3.0"
-    "@jridgewell/trace-mapping" "^0.3.9"
-
-"@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
-  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
-
-"@jridgewell/trace-mapping@^0.3.9":
-  version "0.3.14"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz#b231a081d8f66796e475ad588a1ef473112701ed"
-  integrity sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==
-  dependencies:
-    "@jridgewell/resolve-uri" "^3.0.3"
-    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@keepkey/device-protocol@^7.2.4":
   version "7.7.0"
@@ -6690,15 +6629,6 @@ jest-changed-files@^24.9.0:
     execa "^1.0.0"
     throat "^4.0.0"
 
-jest-worker@^26.2.1:
-  version "26.6.2"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-26.6.2.tgz#7f72cbc4d643c365e27b9fd775f9d0eaa9c7a8ed"
-  integrity sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
-  dependencies:
-    "@types/node" "*"
-    merge-stream "^2.0.0"
-    supports-color "^7.0.0"
-
 jest-worker@^27.4.5:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.5.1.tgz#8d146f0900e8973b106b6f73cc1e9a8cb86f8db0"
@@ -8717,16 +8647,6 @@ rollup-plugin-svelte@^7.0.0:
     require-relative "^0.8.7"
     rollup-pluginutils "^2.8.2"
 
-rollup-plugin-terser@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz#e8fbba4869981b2dc35ae7e8a502d5c6c04d324d"
-  integrity sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    jest-worker "^26.2.1"
-    serialize-javascript "^4.0.0"
-    terser "^5.0.0"
-
 rollup-pluginutils@^2.8.2:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
@@ -8987,13 +8907,6 @@ send@0.17.2:
     on-finished "~2.3.0"
     range-parser "~1.2.1"
     statuses "~1.5.0"
-
-serialize-javascript@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
-  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
-  dependencies:
-    randombytes "^2.1.0"
 
 serialize-javascript@^6.0.0:
   version "6.0.0"
@@ -9528,7 +9441,7 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-supports-color@^7.0.0, supports-color@^7.1.0:
+supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
@@ -9670,16 +9583,6 @@ terser-webpack-plugin@^5.1.3:
     serialize-javascript "^6.0.0"
     source-map "^0.6.1"
     terser "^5.7.2"
-
-terser@^5.0.0:
-  version "5.14.2"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.14.2.tgz#9ac9f22b06994d736174f4091aa368db896f1c10"
-  integrity sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==
-  dependencies:
-    "@jridgewell/source-map" "^0.3.2"
-    acorn "^8.5.0"
-    commander "^2.20.0"
-    source-map-support "~0.5.20"
 
 terser@^5.7.2:
   version "5.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2455,6 +2455,142 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.0"
 
+"@web3-onboard/coinbase@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/coinbase/-/coinbase-2.0.10.tgz#047914b355e7cff70e24a7f2cd443a16b9fa9f13"
+  integrity sha512-baI+gMxPfaS/79xzpqR2wgj46T9klL3ntWrDgtXti2rOzgUTEmElx8znJzfD/H01UykKIfP9mre6W+x3OZXLCw==
+  dependencies:
+    "@coinbase/wallet-sdk" "^3.0.5"
+    "@web3-onboard/common" "^2.1.7"
+
+"@web3-onboard/common@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/common/-/common-2.1.7.tgz#62c74726ed9dd6e8baadab1e6aec6462d62e7d2d"
+  integrity sha512-4nJvfNl0t5D17B1jD8H9BNBtUOVDDHxyxmRyQxnv1u1D5dgdd2I/mUVGhee0xWIHgMy9ORjuJCApraYCwZfgJA==
+  dependencies:
+    "@ethereumjs/common" "2.6.2"
+    bignumber.js "^9.0.0"
+    ethers "5.5.4"
+    joi "^17.4.2"
+    rxjs "^7.5.2"
+
+"@web3-onboard/dcent@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/dcent/-/dcent-2.0.7.tgz#34a2eb673fdde78832e94b83a0210a9a4805971f"
+  integrity sha512-pNokoXqbJZPm3AOpelpC2Ul33ETmqaUmuxvDE9dPgPCSThaskeX/HLkdJJQ5pv3c9ZswSWHHP1IzeevvxzJ4vA==
+  dependencies:
+    "@ethereumjs/common" "^2.6.1"
+    "@ethereumjs/tx" "^3.4.0"
+    "@ethersproject/providers" "^5.5.0"
+    "@web3-onboard/common" "^2.1.7"
+    eth-dcent-keyring "^0.2.2"
+
+"@web3-onboard/fortmatic@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/fortmatic/-/fortmatic-2.0.9.tgz#b0964de85f0785a4248b926c4ec6f3e444e6518e"
+  integrity sha512-3xd8Irs/DjQp88/yjM2ZR4H3FTnTTs4sa8QslAC72Z8GlDKiZ8RxVRMwU/OSBopiW+aEWyvgihq6OdOJux+JMQ==
+  dependencies:
+    "@web3-onboard/common" "^2.1.7"
+    fortmatic "^2.2.1"
+
+"@web3-onboard/gnosis@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/gnosis/-/gnosis-2.0.8.tgz#975ed6cccc9f7189749f3b75b240f53368428dae"
+  integrity sha512-/cdI3jpzn95fOCU0BSuTf6URF6IZB4f0DVOjqgkVPKD+Szh/35gu7FGRZIbv0xwyk6yslUhQpnygy5jyBTvloQ==
+  dependencies:
+    "@gnosis.pm/safe-apps-provider" "^0.9.2"
+    "@gnosis.pm/safe-apps-sdk" "^6.1.1"
+    "@web3-onboard/common" "^2.1.7"
+
+"@web3-onboard/injected-wallets@^2.0.15":
+  version "2.0.15"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/injected-wallets/-/injected-wallets-2.0.15.tgz#ad1cfe3d0ffc20c2383e813a1f25d4f4c1f88562"
+  integrity sha512-hx32yrYWtNbLxKJvIYmKRp0dJUre+Yuc9l3JIUXO4IV1XMXiCAKxKEiJOyloaPREummCNU8+q0pXtmpdYfVrrQ==
+  dependencies:
+    "@web3-onboard/common" "^2.1.7"
+    joi "^17.4.2"
+    lodash.uniqby "^4.7.0"
+
+"@web3-onboard/keepkey@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/keepkey/-/keepkey-2.1.7.tgz#02f3cf263806bb8c048b99e4b4b429fc9cc32087"
+  integrity sha512-stPQI00r+BprMedW1ETyMZA+0g9gxAJt1RTcid/LO/FML5uc1aZImhhGXY2+baJsvdnJIC6yjgKJ1KslFntmhA==
+  dependencies:
+    "@ethersproject/providers" "^5.5.0"
+    "@shapeshiftoss/hdwallet-core" "^1.15.2"
+    "@shapeshiftoss/hdwallet-keepkey-webusb" "^1.15.2"
+    "@web3-onboard/common" "^2.1.7"
+    ethereumjs-util "^7.1.3"
+
+"@web3-onboard/keystone@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/keystone/-/keystone-2.1.8.tgz#ae0f8e1d51e3bdbeba57f2774a4a9336e387774c"
+  integrity sha512-mXmds+goR6aIEuWpNGYNtVgjiCpflQUmjR00zv+dyw/5iJqOvEwX4ybnxDyXGVhPMxVw8bUv2mYBrtC3ourD2w==
+  dependencies:
+    "@ethereumjs/tx" "^3.4.0"
+    "@ethersproject/providers" "^5.5.0"
+    "@keystonehq/eth-keyring" "^0.14.0-alpha.10.3"
+    "@web3-onboard/common" "^2.1.7"
+
+"@web3-onboard/magic@^2.0.10":
+  version "2.0.10"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/magic/-/magic-2.0.10.tgz#04fcb0d5a4034b4abfcc62bd6708d267b9df752d"
+  integrity sha512-4Jo+hJ+nJksvfDhOkMSfM3N1ocwPxm67ZUAymOEAht18zMNDh1ncqY4QMi6BPQeV1eG+Cukwzb9OGixyWw/dNQ==
+  dependencies:
+    "@web3-onboard/common" "^2.1.7"
+    joi "^17.4.2"
+    magic-sdk "^8.1.0"
+    rxjs "^7.5.2"
+
+"@web3-onboard/portis@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/portis/-/portis-2.0.7.tgz#c13cd3c933d94f4c85411f005e1cfc6641e58910"
+  integrity sha512-/JIddbPuLoi30s8tcUxyI73j7ih7jYCcDlANyDZUXAyJuB01w3IW/pnmRNXWMnZZFeludRpDbi88J5apsbe/Dw==
+  dependencies:
+    "@portis/web3" "^4.0.6"
+    "@web3-onboard/common" "^2.1.7"
+
+"@web3-onboard/torus@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/torus/-/torus-2.0.8.tgz#22cc7dfb9cac7cf1818aca1c74c82e977b44b7d4"
+  integrity sha512-brVtHsoourwpiYauhoHJsRbScklouLugdnVeNGJEcZ169LsnbVk4Qclw5xkPYFUWaNEJVxMN8Khr6CQFFQCJQg==
+  dependencies:
+    "@toruslabs/torus-embed" "^1.18.3"
+    "@web3-onboard/common" "^2.1.7"
+
+"@web3-onboard/trezor@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/trezor/-/trezor-2.1.7.tgz#358c79a477ca2c0aa673752fbc37a3a32ec55cf3"
+  integrity sha512-pSHSQDeyNgB8awXWOKh6lTTglbaYgqjjorthlRj/y8+92O4tyFhPi2OZJfpjJ+Fg9v2W6/pfggBLOFyEVLz0kw==
+  dependencies:
+    "@ethereumjs/tx" "^3.4.0"
+    "@ethersproject/providers" "^5.5.0"
+    "@web3-onboard/common" "^2.1.7"
+    buffer "^6.0.3"
+    eth-crypto "^2.1.0"
+    ethereumjs-util "^7.1.3"
+    hdkey "^2.0.1"
+    trezor-connect "^8.2.6"
+
+"@web3-onboard/walletconnect@^2.0.8":
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.0.8.tgz#15d412de1adc3c475d627942132ace314994345c"
+  integrity sha512-3a++pDWa0SO8isFbdc6DB3x5CPWgeIMm1TOMqFKLbHKVJLjQ6tTG48p+xti/5DsRc1nxmVKFitxwWbFTDnjCQA==
+  dependencies:
+    "@ethersproject/providers" "^5.5.0"
+    "@walletconnect/client" "^1.7.1"
+    "@walletconnect/qrcode-modal" "^1.7.1"
+    "@web3-onboard/common" "^2.1.7"
+    rxjs "^7.5.2"
+
+"@web3-onboard/web3auth@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/web3auth/-/web3auth-2.0.6.tgz#2d89a6ed24bc0ef6065f85441b3e99354442991e"
+  integrity sha512-fKBB0XslKccvHbZDAaeKmSrh90Zh8sHn8mI2EJN34Ds1quP1rs2UqftxtwtjrEnFlg88yIu4+35FvNKyViLPiA==
+  dependencies:
+    "@web3-onboard/common" "^2.1.7"
+    "@web3auth/web3auth" "^1.0.0"
+
 "@web3auth/base-plugin@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@web3auth/base-plugin/-/base-plugin-1.0.1.tgz#1e2a87acf745299fdff6f92e6c46ee9bc38aa670"


### PR DESCRIPTION
### Description
This PR is to remove Terser (the rollup package that minifies) from Common and Core packages.
This changes requires bumping all packages that use/import Common or Core packages

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] I have run `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
