### PR TITLE
Fix CI config for hw-common

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -563,7 +563,7 @@ workflows:
           <<: *deploy_staging_filters
   hw-common:
     jobs:
-      - build-common:
+      - build-hw-common:
           <<: *deploy_production_filters
-      - build-staging-common:
+      - build-staging-hw-common:
           <<: *deploy_staging_filters


### PR DESCRIPTION
### Description
Fix CI config for hw-common

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] I have run `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
