### PR TITLE
[fix]: Fixes typo

### DIFF
--- a/packages/core/.eslintrc.cjs
+++ b/packages/core/.eslintrc.cjs
@@ -38,6 +38,7 @@ module.exports = {
       }
     ],
     'object-curly-spacing': ['error', 'always'],
-    '@typescript-eslint/no-empty-function': 'off'
+    '@typescript-eslint/no-empty-function': 'off',
+    quotes: ['error', 'single', { allowTemplateLiterals: true }]
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.8.1",
+  "version": "2.8.2-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/replacement.ts
+++ b/packages/core/src/replacement.ts
@@ -12,7 +12,8 @@ const WALLETS_SUPPORT_REPLACEMENT: WalletState['label'][] = [
   'Ledger',
   'Trezor',
   'Keystone',
-  'Keepkey'
+  'KeepKey',
+  `D'CENT`
 ]
 
 export const actionableEventCode = (eventCode: string): boolean =>


### PR DESCRIPTION
### Description
This PR fixes a typo that was causing the replacement UI to not display on notifications when initiated on a KeepKey wallet. Also added to the list of wallets that support replacement tx's is D'Cent wallet.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
