### PR TITLE
[torus-v2.1.2-alpha.2] : Fix - Lock torus dep version

### DIFF
--- a/packages/torus/package.json
+++ b/packages/torus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/torus",
-  "version": "2.1.2-alpha.1",
+  "version": "2.1.2-alpha.2",
   "description": "Torus SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -56,7 +56,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@toruslabs/torus-embed": "^1.18.3",
-    "@web3-onboard/common": "^2.2.2-alpha.1"
+    "@toruslabs/torus-embed": "1.27.3",
+    "@web3-onboard/common": "^2.2.2"
   }
 }

--- a/packages/torus/package.json
+++ b/packages/torus/package.json
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "@toruslabs/torus-embed": "1.27.3",
-    "@web3-onboard/common": "^2.2.2"
+    "@web3-onboard/common": "^2.2.2-alpha.1"
   }
 }


### PR DESCRIPTION
### Description
Lock torus dep version to last non-breaking change at `1.27.3` as `1.28.0` and later have changes to the API types cause build issues

<img width="1417" alt="Screen Shot 2022-09-06 at 1 44 44 PM" src="https://user-images.githubusercontent.com/24457880/188724871-e67ade52-03de-4a9a-af49-ac2c4e6431c0.png">


### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
