### PR TITLE
Fix error message for account center container element query reference

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -328,7 +328,7 @@ function mountApp() {
 
   if (!containerElement) {
     throw new Error(
-      `Element with query ${state.get().accountCenter} does not exist.`
+      `Element with query ${containerElementQuery} does not exist.`
     )
   }
 


### PR DESCRIPTION
### Description

The query reference for the account center container element is not correct and will output `Element with query [object Object] does not exist`.
