### PR TITLE
[core-v2.8.4-alpha.1]: Fix - AC UI balance & rpcUrl whitespace bug

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.8.3",
+  "version": "2.8.4-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/store/actions.ts
+++ b/packages/core/src/store/actions.ts
@@ -64,10 +64,11 @@ export function addChains(chains: Chain[]): void {
   // chains are validated on init
   const action = {
     type: ADD_CHAINS,
-    payload: chains.map(({ namespace = 'evm', id, ...rest }) => ({
+    payload: chains.map(({ namespace = 'evm', id, rpcUrl, ...rest }) => ({
       ...rest,
       namespace,
-      id: id.toLowerCase()
+      id: id.toLowerCase(),
+      rpcUrl: rpcUrl.trim()
     }))
   }
 

--- a/packages/core/src/views/Index.svelte
+++ b/packages/core/src/views/Index.svelte
@@ -336,7 +336,7 @@
 
   @media all and (min-width: 428px) {
     .container {
-      max-width: 348px;
+      max-width: 352px;
     }
   }
 </style>

--- a/packages/core/src/views/account-center/Maximized.svelte
+++ b/packages/core/src/views/account-center/Maximized.svelte
@@ -13,7 +13,7 @@
   import WalletAppBadge from '../shared/WalletAppBadge.svelte'
   import { getDefaultChainStyles, unrecognizedChainStyle } from '../../utils.js'
   import SuccessStatusIcon from '../shared/SuccessStatusIcon.svelte'
-  import NetworkBadgeSelector from '../shared/NetworkSelector.svelte'
+  import NetworkSelector from '../shared/NetworkSelector.svelte'
   import caretLightIcon from '../../icons/caret-light.js'
   import warningIcon from '../../icons/warning.js'
   import questionIcon from '../../icons/question.js'
@@ -137,6 +137,7 @@
 
   .network-selector-container {
     margin-left: 1rem;
+    width: 100%;
   }
 
   .network-selector-label {
@@ -336,12 +337,13 @@
               default: en.accountCenter.currentNetwork
             })}
           </div>
-          <div on:click class="flex items-center">
-            <NetworkBadgeSelector
+          <div on:click class="flex items-center" style=" width: 100%;">
+            <NetworkSelector
               chains={appChains}
               colorVar="--account-center-maximized-network-selector-color"
               bold={true}
               selectIcon={caretLightIcon}
+              parentCSSId="maximized_ac"
             />
           </div>
         </div>

--- a/packages/core/src/views/account-center/Minimized.svelte
+++ b/packages/core/src/views/account-center/Minimized.svelte
@@ -90,8 +90,10 @@
     font-weight: 400;
     line-height: var(--onboard-font-line-height-2, var(--font-line-height-2));
     color: var(--onboard-gray-400, var(--gray-400));
+    overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    width: 7.25rem;
   }
 
   .network {
@@ -212,6 +214,7 @@
             {chains}
             colorVar="--account-center-minimized-network-selector-color"
             selectIcon={caretIcon}
+            parentCSSId="minimized_ac"
           />
         </div>
       </div>

--- a/packages/core/src/views/account-center/Minimized.svelte
+++ b/packages/core/src/views/account-center/Minimized.svelte
@@ -90,10 +90,12 @@
     font-weight: 400;
     line-height: var(--onboard-font-line-height-2, var(--font-line-height-2));
     color: var(--onboard-gray-400, var(--gray-400));
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   .network {
-    margin-left: 0.5rem;
+    margin-left: 0.2rem;
   }
 
   .chain-icon {

--- a/packages/core/src/views/account-center/WalletRow.svelte
+++ b/packages/core/src/views/account-center/WalletRow.svelte
@@ -97,11 +97,15 @@
     margin-left: 0.5rem;
     color: var(--onboard-gray-300, var(--gray-300));
     transition: color 150ms ease-in-out, background-color 150ms ease-in-out;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: 7.25rem;
   }
 
   .elipsis-container {
     padding: 0.25rem;
-    margin-left: 0.5rem;
+    margin-left: 0.25rem;
     border-radius: 24px;
     transition: color 150ms ease-in-out, background-color 150ms ease-in-out;
     background-color: transparent;

--- a/packages/core/src/views/shared/NetworkSelector.svelte
+++ b/packages/core/src/views/shared/NetworkSelector.svelte
@@ -11,6 +11,7 @@
   export let colorVar: string
   export let chains: Chain[]
   export let bold = false
+  export let parentCSSId = ''
 
   const switching$ = new BehaviorSubject<boolean>(false)
   let selectElement: HTMLSelectElement
@@ -73,8 +74,6 @@
     appearance: none;
     font-size: var(--onboard-font-size-7, var(--font-size-7));
     line-height: var(--onboard-font-line-height-3, var(--font-line-height-3));
-    min-width: 80px;
-    max-width: 80px;
     transition: width 250ms ease-in-out;
     background-repeat: no-repeat, repeat;
     background-position: right 0px top 0px, 0 0;
@@ -83,6 +82,15 @@
     padding: 0 14px 0 0;
     white-space: nowrap;
     text-overflow: ellipsis;
+  }
+
+  select.minimized_ac {
+    min-width: 80px;
+    max-width: 80px;
+  }
+
+  select.maximized_ac {
+    width: auto !important;
   }
 
   select:focus {
@@ -101,7 +109,7 @@
 {#if wallet}
   {#if $switching$}
     <span
-      class="switching-placeholder"
+      class={`switching-placeholder ${parentCSSId}`}
       style={`
         color: var(${colorVar}, 
         var(--account-center-network-selector-color, var (--gray-500))); 
@@ -109,7 +117,7 @@
     >
   {:else}
     <select
-      class="flex justify-center items-center pointer"
+      class={`flex justify-center items-center pointer ${parentCSSId}`}
       bind:this={selectElement}
       value={wallet.chains[0].id}
       on:change={handleSelect}

--- a/packages/core/src/views/shared/NetworkSelector.svelte
+++ b/packages/core/src/views/shared/NetworkSelector.svelte
@@ -73,35 +73,39 @@
     appearance: none;
     font-size: var(--onboard-font-size-7, var(--font-size-7));
     line-height: var(--onboard-font-line-height-3, var(--font-line-height-3));
-    max-width: 90px;
-    min-width: 72px;
+    min-width: 80px;
+    max-width: 80px;
     transition: width 250ms ease-in-out;
     background-repeat: no-repeat, repeat;
     background-position: right 0px top 0px, 0 0;
     scrollbar-width: none;
     -ms-overflow-style: none;
-    padding: 0 16px 0 0;
+    padding: 0 14px 0 0;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   select:focus {
     outline: none;
   }
 
-  span {
+  span.switching-placeholder {
     font-size: var(--onboard-font-size-7, var(--font-size-7));
     line-height: var(--onboard-font-line-height-3, var(--font-line-height-3));
+    min-width: 80px;
+    max-width: 80px;
+    padding: 0 8px 0 4px;
   }
 </style>
 
 {#if wallet}
   {#if $switching$}
     <span
+      class="switching-placeholder"
       style={`
         color: var(${colorVar}, 
         var(--account-center-network-selector-color, var (--gray-500))); 
-        padding: 0 8px 0 4px;
-      `}
-      >switching...</span
+      `}>switching...</span
     >
   {:else}
     <select

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@web3-onboard/coinbase": "^2.1.2",
-    "@web3-onboard/core": "^2.8.2",
+    "@web3-onboard/core": "^2.8.4-alpha.1",
     "@web3-onboard/dcent": "^2.2.0",
     "@web3-onboard/fortmatic": "^2.0.13",
     "@web3-onboard/gas": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,10 +2953,10 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.0"
 
-"@web3-onboard/core@^2.8.2":
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.8.2.tgz#70d1730384a3e028bbe07769086361db5c631d78"
-  integrity sha512-AE2xQVKsmjtvW7lI7xFFdfAtoLxmZRa9qfCv5MtHRDY9Ojqkj06dLgteJmB4FBFZnh79iXoKbIj7N+vRpvjHIw==
+"@web3-onboard/core@^2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.8.3.tgz#e41c3e11b5a38d7b5e2ee15d4dc2cf49307d38c5"
+  integrity sha512-3CKc33dKqC9jurbf0+7mfvddBJgvCU4n9ADu68XlmCws3xP8Gq1nji4Y/AEUqcfhfdPWno6vIgc/j1cYseCIhw==
   dependencies:
     "@web3-onboard/common" "^2.2.2"
     bignumber.js "^9.0.0"


### PR DESCRIPTION
### Description
Fix overflow within the Account Center balance where the balance runs outside of the AC container.
To do this ellipsis were used and a max container width both on max & min AC.
<img width="340" alt="Screen Shot 2022-09-13 at 1 05 36 PM" src="https://user-images.githubusercontent.com/24457880/190223157-de6d0d1d-6b98-4871-9539-6a7d70768c88.png">
<img width="351" alt="Screen Shot 2022-09-13 at 1 05 28 PM" src="https://user-images.githubusercontent.com/24457880/190223162-1520914f-ba68-483e-8f7e-59d3251a3489.png">


Also fixed a bug where is there was any trailing or beginning spaces on the rpcUrl string when adding a new network an error is thrown.
This was accomplished by trimming the whitespace on rpcUrls when setting them in W3O state upon initialization.
Error thrown prior to fix when whitespace was present:
<img width="1122" alt="Screen Shot 2022-09-13 at 9 14 25 AM" src="https://user-images.githubusercontent.com/24457880/190222924-9753f1d5-8e70-4658-9b0e-d25ba715769e.png">


### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
