### PR TITLE
fix issue eth_signTypedData_v4 not supported

### DIFF
--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletconnect",
-  "version": "2.1.2",
+  "version": "2.1.3-alpha.1",
   "description": "WalletConnect SDK module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -206,7 +206,7 @@ function walletConnect(options?: WalletConnectOptions): WalletInit {
               }
 
               // @ts-ignore
-              if (method === 'eth_signTypedData') {
+              if (method === 'eth_signTypedData' || method === 'eth_signTypedData_v4') {
                 // @ts-ignore
                 return this.connector.signTypedData(params)
               }

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -206,7 +206,7 @@ function walletConnect(options?: WalletConnectOptions): WalletInit {
               }
 
               // @ts-ignore
-              if (method === 'eth_signTypedData' || method === 'eth_signTypedData_v4') {
+              if (method.includes('eth_signTypedData') {
                 // @ts-ignore
                 return this.connector.signTypedData(params)
               }


### PR DESCRIPTION
### Description
#1271 
I console the requet method type in this file and found  the Incoming parameters is  eth_signTypedData_v4  when use  _signTypedData  method in ethers.js framework.



### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
