### PR TITLE
[fix] - MetaMask Connect Flow

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.8.5-alpha.1",
+  "version": "2.8.5-alpha.2",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/i18n/en.json
+++ b/packages/core/src/i18n/en.json
@@ -25,6 +25,7 @@
       },
       "mainText": "Connecting...",
       "paragraph": "Make sure to select all accounts that you want to grant access to.",
+      "previousConnection": "{wallet} already has a pending connection request, please open the menu to login and connect",
       "rejectedText": "Connection Rejected!",
       "rejectedCTA": "Click here to try again",
       "primaryButton": "Back to wallets"

--- a/packages/core/src/i18n/en.json
+++ b/packages/core/src/i18n/en.json
@@ -25,7 +25,7 @@
       },
       "mainText": "Connecting...",
       "paragraph": "Make sure to select all accounts that you want to grant access to.",
-      "previousConnection": "{wallet} already has a pending connection request, please open the menu to login and connect",
+      "previousConnection": "{wallet} already has a pending connection request, please open the {wallet} app to login and connect.",
       "rejectedText": "Connection Rejected!",
       "rejectedCTA": "Click here to try again",
       "primaryButton": "Back to wallets"

--- a/packages/core/src/views/connect/ConnectingWallet.svelte
+++ b/packages/core/src/views/connect/ConnectingWallet.svelte
@@ -12,6 +12,7 @@
   export let deselectWallet: (label: string) => void
   export let setStep: (update: keyof i18n['connect']) => void
   export let connectionRejected: boolean
+  export let previousConnectionRequest: boolean
 
   const { appMetadata } = configuration
 </script>
@@ -69,7 +70,7 @@
 <div class="container flex flex-column items-center">
   <div
     class="connecting-container flex justify-between items-center"
-    class:warning={connectionRejected}
+    class:warning={connectionRejected || previousConnectionRequest}
   >
     <div class="flex">
       <div class="flex justify-center relative">
@@ -77,7 +78,9 @@
           size={40}
           padding={8}
           icon={(appMetadata && appMetadata.icon) || questionIcon}
-          border={connectionRejected ? 'yellow' : 'blue'}
+          border={connectionRejected || previousConnectionRequest
+            ? 'yellow'
+            : 'blue'}
           background="lightGray"
         />
 
@@ -85,7 +88,9 @@
           <WalletAppBadge
             size={40}
             padding={8}
-            border={connectionRejected ? 'yellow' : 'blue'}
+            border={connectionRejected || previousConnectionRequest
+              ? 'yellow'
+              : 'blue'}
             background="white"
             icon={selectedWallet.icon}
           />
@@ -95,9 +100,9 @@
       <div class="flex flex-column justify-center ml">
         <div class="text" class:text-rejected={connectionRejected}>
           {$_(
-            connectionRejected
-              ? 'connect.connectingWallet.rejectedText'
-              : 'connect.connectingWallet.mainText',
+            `connect.connectingWallet.${
+              connectionRejected ? 'rejectedText' : 'mainText'
+            }`,
             {
               default: connectionRejected
                 ? en.connect.connectingWallet.rejectedText
@@ -113,9 +118,15 @@
           </div>
         {:else}
           <div class="subtext">
-            {$_('connect.connectingWallet.paragraph', {
-              default: en.connect.connectingWallet.paragraph
-            })}
+            {$_(
+              `connect.connectingWallet.${
+                previousConnectionRequest ? 'previousConnection' : 'paragraph'
+              }`,
+              {
+                default: en.connect.connectingWallet.paragraph,
+                values: { wallet: selectedWallet.label }
+              }
+            )}
           </div>
         {/if}
       </div>

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -259,6 +259,7 @@
 
         if (autoSelect.disableModals) {
           connectWallet$.next({ inProgress: false })
+          return
         }
 
         listenAccountsChanged({


### PR DESCRIPTION
### Description
This PR fixes some edge cases that occur when connecting to MetaMask. If a connect request is made and the user clicks outside of the popup menu (which hides the login/connect popup), and then tries to connect again, the connect request will throw an error and Onboard will not be aware that there is another connect request in progress. This gets especially complicated when the `autoSelect` feature is used modals disabled as the app cannot know that the original request is hanging leading to a bad UX as outlined in #1279. This fix will work for any wallets that throw an RPC error for duplicate connect requests. As far as I am aware only MetaMask does this at this time.

The fix does the following:

- Ensures that only one connect request is in flight at any time. It does this via canceling the any old requests whenever a new connect request is fired.
- Ensures that when the user does eventually connect their MetaMask wallet that Onboard will recognize that connection separately from the connection request as that is unreliable in this edge case. It does this by listening to the `accountsChanged` event when an account access already requested RPC error is caught.
- Adds some new copy to the connecting modal to indicate that a pending connect request is awaiting user action and that the user needs to manually open the MetaMask menu as it will not popup a second time.

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
