### PR TITLE
Enhancement: Sync accounts

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.8.5",
+  "version": "2.9.0-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -343,3 +343,15 @@ export type DeviceNotBrowser = {
   os: null
   browser: null
 }
+
+export type WalletPermission = {
+  id: string
+  parentCapability: string
+  invoker: string
+  caveats: {
+    type: string
+    value: string[]
+  }[]
+
+  date: number
+}


### PR DESCRIPTION
### Description
Currently, if a user were to connect multiple MetaMask accounts and then manually disconnect one of those accounts, the disconnected account will still appear connected in the internal `wallets` state and associated UI's driven by that state.

This change implements logic to handle this for wallets that support the `wallet_getPermissions` RPC method, which allows us to check which accounts are currently connected and compare them with our internal connected accounts state and then sync them.

Closes #1225 

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
