### PR TITLE
fix: Remove overflow property on document element when modal closes

### DIFF
--- a/packages/core/src/views/shared/Modal.svelte
+++ b/packages/core/src/views/shared/Modal.svelte
@@ -42,7 +42,7 @@
   onDestroy(() => {
     device.type === 'mobile'
       ? (html.style.position = '')
-      : (html.style.overflow = 'auto')
+      : (html.style.removeProperty('overflow'))
     const scrollY = body.style.top
     body.style.top = ''
     window.scrollTo(0, parseInt(scrollY || '0') * -1)


### PR DESCRIPTION
### Description
Resolves #1309 

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
