### PR TITLE
Add isBitski provider flag

### DIFF
--- a/packages/injected/src/types.ts
+++ b/packages/injected/src/types.ts
@@ -47,7 +47,8 @@ export enum ProviderIdentityFlag {
   BitKeep = 'isBitKeep',
   Sequence = 'isSequence',
   Core = 'isAvalanche',
-  Opera = 'isOpera'
+  Opera = 'isOpera',
+  Bitski = 'isBitski'
 }
 
 export enum ProviderLabel {


### PR DESCRIPTION
### Description
Add `isBitski` provider flag options as Bitski as isMetamask set to true

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
