### PR TITLE
[gas-v2.1.4-alpha.1]: Fix - Update gas package to contain main and browser entry points

### DIFF
--- a/packages/gas/package.json
+++ b/packages/gas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/gas",
-  "version": "2.1.3",
+  "version": "2.1.4-alpha.1",
   "description": "Estimate the gas prices needed to get a transaction in to the next block for Ethereum Mainnet and Polygon Matic Mainnet.",
   "keywords": [
     "gas",
@@ -16,6 +16,8 @@
   "bugs": "https://github.com/blocknative/web3-onboard/issues",
   "module": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "browser": "dist/index.js",
+  "main": "dist/index.js",
   "files": [
     "dist"
   ],

--- a/packages/gnosis/README.md
+++ b/packages/gnosis/README.md
@@ -33,3 +33,27 @@ const onboard = Onboard({
 const connectedWallets = await onboard.connectWallet()
 console.log(connectedWallets)
 ```
+
+## Customizing Gnosis Transaction Gas
+
+If you are looking to set the `gasLimit` of a transaction within Gnosis, the gas properties within the transaction WILL BE IGNORED.
+Instead you will need to use the `safeTxGas` prop AND the web3-onboard Gnosis instance that is exposed through the provider to send along the transaction.
+The Gnosis sdk instance exposed by the web3-onboard must be used to set the `safeTxGas` prop and send the transaction.
+Check [Gnosis docs](https://github.com/safe-global/safe-contracts/blob/a6504a9afdeac186a8cdb29ad68b189523c80eda/docs/safe_tx_gas.md) for full detail as it can be a bit confusing.
+An example of accessing the Gnosis SDK instance and sending a transaction can be found below.
+
+```typescript
+const tx = {
+  to: toAddress,
+  value: 1000000000000000,
+  data: '0x',
+}
+const params = {
+  safeTxGas: 5000000,
+};
+
+// wallet is the provider exposed by web3-onboard after the Gnosis wallet is connected
+let trans = await wallet.instance.txs.send({txs:[tx], params})
+```
+
+Note: With the `safeTxGas` you will see additional value on the `gasLimit` displayed in the Safe. Check [Gnosis docs](https://github.com/safe-global/safe-contracts/blob/a6504a9afdeac186a8cdb29ad68b189523c80eda/docs/safe_tx_gas.md) for full details on that computation.

--- a/packages/gnosis/package.json
+++ b/packages/gnosis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/gnosis",
-  "version": "2.1.3",
+  "version": "2.1.4-alpha.1",
   "description": "Gnosis Safe module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -56,7 +56,7 @@ function App() {
     <div>
       <button
         disabled={connecting}
-        onClick={() => (wallet ? disconnect() : connect())}
+        onClick={() => (wallet ? disconnect(wallet) : connect())}
       >
         {connecting ? 'connecting' : wallet ? 'disconnect' : 'connect'}
       </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,6 +2953,15 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.0"
 
+"@web3-onboard/gas@^2.0.0", "@web3-onboard/gas@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/gas/-/gas-2.1.3.tgz#1f4f2da8e758dba6bb2cdca8e552dcc801c4981d"
+  integrity sha512-5k3O5bX0hdJvGvi1w5ztUg8/muJeyPTuzcryCOnY1/PoSq/znUy3z1Qjl3V1zJtUhKydirPRzXEbUushjQ1VVQ==
+  dependencies:
+    "@web3-onboard/common" "^2.2.3"
+    joi "^17.6.1"
+    rxjs "^7.5.2"
+
 "@web3auth/base-plugin@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@web3auth/base-plugin/-/base-plugin-1.0.1.tgz#1e2a87acf745299fdff6f92e6c46ee9bc38aa670"


### PR DESCRIPTION
### Description
Updated the Gas package.json to align with other packages.
Without this change the entire path is required when importing `@web3-onboard/gas` for the build to succeed
`import gasModule from '@web3-onboard/gas/dist/index.js'`

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
