### PR TITLE
[core, react, vue]: Fix - Chain id to hex on change

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.10.0",
+  "version": "2.10.1-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -5,7 +5,7 @@ import { providers } from 'ethers'
 import { weiToEth } from '@web3-onboard/common'
 import { disconnectWallet$ } from './streams.js'
 import { updateAccount, updateWallet } from './store/actions.js'
-import { validEnsChain } from './utils.js'
+import { toHexString, validEnsChain } from './utils.js'
 import disconnect from './disconnect.js'
 import { state } from './store/index.js'
 import { getBlocknativeSdk } from './services.js'
@@ -221,7 +221,7 @@ export function trackWallet(
   // Update chain on wallet when chainId changed
   chainChanged$.subscribe(async (chainId: string | number) => {
     const hexChainId: string =
-      typeof chainId === 'number' ? `0x${chainId.toString(16)}` : chainId
+      typeof chainId === 'number' ? toHexString(chainId) : chainId
     const { wallets } = state.get()
     const { chains, accounts } = wallets.find(wallet => wallet.label === label)
     const [connectedWalletChain] = chains

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -219,12 +219,14 @@ export function trackWallet(
   )
 
   // Update chain on wallet when chainId changed
-  chainChanged$.subscribe(async chainId => {
+  chainChanged$.subscribe(async (chainId: string | number) => {
+    const hexChainId: string =
+      typeof chainId === 'number' ? `0x${chainId.toString(16)}` : chainId
     const { wallets } = state.get()
     const { chains, accounts } = wallets.find(wallet => wallet.label === label)
     const [connectedWalletChain] = chains
 
-    if (chainId === connectedWalletChain.id) return
+    if (hexChainId === connectedWalletChain.id) return
 
     if (state.get().notify.enabled) {
       const sdk = await getBlocknativeSdk()
@@ -249,7 +251,7 @@ export function trackWallet(
           try {
             sdk.subscribe({
               id: address,
-              chainId: chainId,
+              chainId: hexChainId,
               type: 'account'
             })
           } catch (error) {
@@ -269,7 +271,7 @@ export function trackWallet(
     )
 
     updateWallet(label, {
-      chains: [{ namespace: 'evm', id: chainId }],
+      chains: [{ namespace: 'evm', id: hexChainId }],
       accounts: resetAccounts
     })
   })

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@web3-onboard/coinbase": "^2.1.3",
-    "@web3-onboard/core": "^2.10.0",
+    "@web3-onboard/core": "^2.10.1-alpha.1",
     "@web3-onboard/dcent": "^2.2.2",
     "@web3-onboard/fortmatic": "^2.0.14",
     "@web3-onboard/gas": "^2.1.3",

--- a/packages/demo/src/App.svelte
+++ b/packages/demo/src/App.svelte
@@ -931,8 +931,8 @@
           <button on:click={() => onboard.setChain({ chainId: '0x1' })}
             >Set Chain to Mainnet</button
           >
-          <button on:click={() => onboard.setChain({ chainId: '0x4' })}
-            >Set Chain to Rinkeby</button
+          <button on:click={() => onboard.setChain({ chainId: '0x5' })}
+            >Set Chain to Goerli</button
           >
           <button on:click={() => onboard.setChain({ chainId: '0x89' })}
             >Set Chain to Matic</button

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.4.0",
+  "version": "2.4.1-alpha.1",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,7 +62,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.10.0",
+    "@web3-onboard/core": "^2.10.1-alpha.1",
     "@web3-onboard/common": "^2.2.3",
     "use-sync-external-store": "1.0.0"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.3.0",
+  "version": "2.3.1-alpha.1",
   "description": "A collection of Vue Composables for integrating Web3-Onboard in to a Vue or Nuxt project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -63,7 +63,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.2.3",
-    "@web3-onboard/core": "^2.10.0",
+    "@web3-onboard/core": "^2.10.1-alpha.1",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,6 +2953,25 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.0"
 
+"@web3-onboard/core@^2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.10.0.tgz#ad6b0dc566a7828928dd87ed29a5a38a62330ad1"
+  integrity sha512-wzg9iefyKmhBmh6R0Jr6kmFqi4hggHaOmPn7pDBrGp/4GvyTjAlVj+42wV9KqJb0MY9ABB1Q8XIKmhtRnXftzQ==
+  dependencies:
+    "@web3-onboard/common" "^2.2.3"
+    bignumber.js "^9.0.0"
+    bnc-sdk "^4.4.1"
+    bowser "^2.11.0"
+    ethers "5.5.3"
+    eventemitter3 "^4.0.7"
+    joi "^17.6.1"
+    lodash.merge "^4.6.2"
+    lodash.partition "^4.6.0"
+    nanoid "^4.0.0"
+    rxjs "^7.5.5"
+    svelte "^3.49.0"
+    svelte-i18n "^3.3.13"
+
 "@web3auth/base-plugin@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@web3auth/base-plugin/-/base-plugin-1.0.1.tgz#1e2a87acf745299fdff6f92e6c46ee9bc38aa670"


### PR DESCRIPTION
### Description
Found a bug where on the internal demo upon using the buttons or Account Center to switch an error was arising(seen below). Upon further investigation I found the ChainId was still a number instead of hex when received from the chainChanged listener.
<img width="884" alt="Screen Shot 2022-10-26 at 12 31 31 PM" src="https://user-images.githubusercontent.com/24457880/198140862-4361e228-f85a-4c49-80f5-3e4fc0bba8bc.png">

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
