### PR TITLE
[BUG] fix coinbase default entry

### DIFF
--- a/packages/coinbase/package.json
+++ b/packages/coinbase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/coinbase",
-  "version": "2.1.3",
+  "version": "2.1.4-alpha.1",
   "description": "Coinbase SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/coinbase/src/index.ts
+++ b/packages/coinbase/src/index.ts
@@ -13,12 +13,17 @@ function coinbaseWallet({
         const [chain] = chains
         const { name, icon } = appMetadata || {}
 
-        const { CoinbaseWalletSDK } = await import('@coinbase/wallet-sdk')
+        const { default: CoinbaseWalletSDK } = await import(
+          '@coinbase/wallet-sdk'
+        )
+        const CoinbaseWalletSDKConstructor = (CoinbaseWalletSDK as any).default
+          ? (CoinbaseWalletSDK as any).default
+          : CoinbaseWalletSDK
 
         const base64 = window.btoa(icon || '')
         const appLogoUrl = `data:image/svg+xml;base64,${base64}`
 
-        const instance = new CoinbaseWalletSDK({
+        const instance = new CoinbaseWalletSDKConstructor({
           appName: name || '',
           appLogoUrl,
           darkMode

--- a/packages/coinbase/src/index.ts
+++ b/packages/coinbase/src/index.ts
@@ -13,12 +13,17 @@ function coinbaseWallet({
         const [chain] = chains
         const { name, icon } = appMetadata || {}
 
+        // according to https://github.com/wagmi-dev/wagmi/issues/383
+        // @coinbase/wallet-sdk export double default fields
+        // so we need to detect it to get the real constructor
         const { default: CoinbaseWalletSDK } = await import(
           '@coinbase/wallet-sdk'
         )
-        const CoinbaseWalletSDKConstructor = (CoinbaseWalletSDK as any).default
-          ? (CoinbaseWalletSDK as any).default
-          : CoinbaseWalletSDK
+        const CoinbaseWalletSDKConstructor = (
+          (CoinbaseWalletSDK as any).default
+            ? (CoinbaseWalletSDK as any).default
+            : CoinbaseWalletSDK
+        ) as typeof CoinbaseWalletSDK
 
         const base64 = window.btoa(icon || '')
         const appLogoUrl = `data:image/svg+xml;base64,${base64}`


### PR DESCRIPTION
### Description
https://github.com/wagmi-dev/wagmi/issues/383, as discussed here, the coinbase wallet export constructor as default, and vite(or not caused by it) will wrap by another default. so we need to detect if the default export is the constructor. if not, use the next default.

![image](https://user-images.githubusercontent.com/1694541/202407499-20ea622f-bf4d-49d8-a5f1-f61b62c9e6ed.png)

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
