### PR TITLE
Change the typing of the chains

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.11.1-alpha.1",
+  "version": "2.11.1-alpha.2",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,7 +25,7 @@ export interface InitOptions {
   /**
    * The chains that your app works with
    */
-  chains: Chain[] | ChainWithDecimalId[]
+  chains: (Chain | ChainWithDecimalId)[]
   /**
    * Additional metadata about your app to be displayed in the Onboard UI
    */

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -96,7 +96,7 @@ export async function copyWalletAddress(text: string): Promise<void> {
 export const toHexString = (val: number | string): string =>
   typeof val === 'number' ? `0x${val.toString(16)}` : val
 
-export function chainIdToHex(chains: Chain[] | ChainWithDecimalId[]): Chain[] {
+export function chainIdToHex(chains: (Chain | ChainWithDecimalId)[]): Chain[] {
   return chains.map(({ id, ...rest }) => {
     const hexId = toHexString(id)
     return { id: hexId, ...rest }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.5.1-alpha.1",
+  "version": "2.5.1-alpha.2",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,7 +62,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.11.1-alpha.1",
+    "@web3-onboard/core": "^2.11.1-alpha.2",
     "@web3-onboard/common": "^2.2.3",
     "use-sync-external-store": "1.0.0"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.4.1-alpha.1",
+  "version": "2.4.1-alpha.2",
   "description": "A collection of Vue Composables for integrating Web3-Onboard in to a Vue or Nuxt project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -63,7 +63,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.2.3",
-    "@web3-onboard/core": "^2.11.1-alpha.1",
+    "@web3-onboard/core": "^2.11.1-alpha.2",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
It is impossible to run any array-specific methods on `chains` since typescript is not able to detect the array type correctly.

<img width="990" alt="Снимок экрана 2022-12-07 в 21 24 34" src="https://user-images.githubusercontent.com/35642018/206276431-f31ad775-c7c2-41f1-8668-b88d125736a8.png">

Example to reproduce:
```typescript
const onboard = Onboard(initOptions)

const chainId = defaultChainId ?? '0x1'
const chain: Chain | ChainWithDecimalId | null = initOptions.chains.find(
   (chain: ChainWithDecimalId | Chain) => chain.id === chainId || chain.id === `0x${chainId.toString(16)}`
)
```
### Description
<!-- Add a description of the fix or feature here -->

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] I have run `yarn file-check`, `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
