### PR TITLE
fix: update 'sequence' pkg name

### DIFF
--- a/packages/sequence/README.md
+++ b/packages/sequence/README.md
@@ -4,7 +4,9 @@
 
 ### Install
 
-`npm i @web3-onboard/sequence @0xsequence ethers`
+`npm i @web3-onboard/sequence 0xsequence ethers`  
+or  
+`yarn add @web3-onboard/sequence 0xsequence ethers`
 
 ## Options
 


### PR DESCRIPTION
### Description
<!-- Add a description of the fix or feature here -->
I followed the instructions in `packages/sequence/README.md` to add sequence to my dapp.
However, the npm packages of this scope `@0xsequence` is no longer available. I was able to install without scoping the package as can be seen in this PR.

### Checklist
- [ ] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [X] The box that allows repo maintainers to update this PR is checked
- [X] I tested locally to make sure this feature/fix works
- [ ] I have run `yarn file-check`, `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks
