### PR TITLE
[injected-wallets: 2.5.0-alpha.2]: Fix - Gamestop chain recognition

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -30,7 +30,7 @@
     "@web3-onboard/fortmatic": "^2.0.14",
     "@web3-onboard/gas": "^2.1.3",
     "@web3-onboard/gnosis": "^2.1.5",
-    "@web3-onboard/injected-wallets": "^2.5.0-alpha.1",
+    "@web3-onboard/injected-wallets": "^2.5.0-alpha.2",
     "@web3-onboard/keepkey": "^2.3.2",
     "@web3-onboard/keystone": "^2.3.2",
     "@web3-onboard/ledger": "^2.3.2",

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.5.0-alpha.1",
+  "version": "2.5.0-alpha.2",
   "description": "Injected wallet module for connecting browser extension and mobile wallets to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/injected/src/wallets.ts
+++ b/packages/injected/src/wallets.ts
@@ -524,9 +524,18 @@ const gamestop: InjectedWalletModule = {
   checkProviderIdentity: ({ provider }) =>
     !!provider && !!provider[ProviderIdentityFlag.GameStop],
   getIcon: async () => (await import('./icons/gamestop.js')).default,
-  getInterface: async () => ({
-    provider: createEIP1193Provider(window.gamestop)
-  }),
+  getInterface: async () => {
+    const provider = createEIP1193Provider(window.gamestop, {
+      eth_chainId: ({ baseRequest }) =>
+        baseRequest({ method: 'eth_chainId' }).then(
+          id => `0x${parseInt(id).toString(16)}`
+        ),
+      wallet_switchEthereumChain: UNSUPPORTED_METHOD
+    })
+    provider.removeListener = (event, listener) => {}
+    provider.on = (event, listener) => {}
+    return { provider }
+  },
   platforms: ['desktop']
 }
 


### PR DESCRIPTION
### Description
Gamestop add a `0` before the numeric representation within single digit hex codes.
This fixes this issue

Example: `0x1` is `0x01` in Gamestop world which doesnt work W3O recognizing chains and styling them in AC

### Checklist
- [x] The version field in `package.json` is incremented following [semantic versioning](https://semver.org/)
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn file-check`, `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
