### PR TITLE
[injected-v2.6.0-alpha.4]: Fix - Filtering out MetaMask

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -31,7 +31,7 @@
     "@web3-onboard/fortmatic": "^2.0.14",
     "@web3-onboard/gas": "^2.1.3",
     "@web3-onboard/gnosis": "^2.1.5",
-    "@web3-onboard/injected-wallets": "^2.6.0-alpha.3",
+    "@web3-onboard/injected-wallets": "^2.6.0-alpha.4",
     "@web3-onboard/keepkey": "^2.3.2",
     "@web3-onboard/keystone": "^2.3.2",
     "@web3-onboard/ledger": "^2.4.1-alpha.1",

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.6.0-alpha.3",
+  "version": "2.6.0-alpha.4",
   "description": "Injected wallet module for connecting browser extension and mobile wallets to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/injected/src/index.ts
+++ b/packages/injected/src/index.ts
@@ -41,8 +41,6 @@ function injected(options?: InjectedWalletOptions): WalletInit {
       ({ label }) => label
     )
 
-    let removeMetaMask = false
-
     const wallets = allWallets.reduce((acc, wallet) => {
       const { label, platforms, injectedNamespace, checkProviderIdentity } =
         wallet
@@ -104,19 +102,6 @@ function injected(options?: InjectedWalletOptions): WalletInit {
         )
       }
 
-      // check to see if we need to remove MetaMask
-      // in the case that the provider gave us a false positive
-      // for MM wallet
-      if (
-        walletAvailable &&
-        provider.isMetaMask &&
-        !provider.overrideIsMetaMask &&
-        label !== ProviderLabel.MetaMask &&
-        label !== 'Detected Wallet'
-      ) {
-        removeMetaMask = true
-      }
-
       return acc
     }, [] as InjectedWalletModule[])
 
@@ -127,12 +112,7 @@ function injected(options?: InjectedWalletOptions): WalletInit {
       const formattedWallets = wallets
         .filter(wallet => {
           const { label } = wallet
-          return !(
-            (label === ProviderLabel.Detected && moreThanOneWallet) ||
-            (label === ProviderLabel.MetaMask &&
-              moreThanOneWallet &&
-              removeMetaMask)
-          )
+          return !(label === ProviderLabel.Detected && moreThanOneWallet)
         })
         // then map to the WalletModule interface
         .map(({ label, getIcon, getInterface }: InjectedWalletModule) => ({


### PR DESCRIPTION
### Description
Prior to this fix if a different wallet had the `isMetaMask` flag set to true and MetaMask was available on the browser - MetaMask would be filtered out.
With the use of `otherProviderFlagsExist` function in the MetaMask `checkProviderIdentity` check (already in place) we check the MM provider against all other known wallet identity flags.
If no other flags exists besides the specified flag (`isMetaMask` in this case) we can safely assume the Wallet is MetaMask and we don't need other checks to filter it out.

One caveat of both approaches would be if an unknown (by W3O) wallet has `isMetaMask` set to true and injects at `window.ethereum` there will be a false positive. With W3O wallet coverage I think we are safe for the most part against this issue and users can find a way around or submit an issue if necessary.

Video: (sound recording didn't work so watch for the reload - first display is old code second is new changes)
https://www.loom.com/share/152cbd7262de440d89fdb8afdfcd3143

### Checklist
- [x] The version field in `package.json` of the package you have made changes in is incremented following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn file-check`, `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
