### PR TITLE
Fix: Torus Chain Changed Error

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -39,7 +39,7 @@
     "@web3-onboard/phantom": "^2.0.0-alpha.1",
     "@web3-onboard/portis": "^2.1.3",
     "@web3-onboard/sequence": "^2.0.4",
-    "@web3-onboard/torus": "^2.2.0",
+    "@web3-onboard/torus": "^2.2.1-alpha.1",
     "@web3-onboard/trezor": "^2.3.2",
     "@web3-onboard/tallyho": "^2.0.1",
     "@web3-onboard/web3auth": "^2.1.4",

--- a/packages/torus/package.json
+++ b/packages/torus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/torus",
-  "version": "2.2.0",
+  "version": "2.2.1-alpha.1",
   "description": "Torus SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/torus/src/index.ts
+++ b/packages/torus/src/index.ts
@@ -55,21 +55,6 @@ function torus(options?: TorusOptions): WalletInit {
 
         const torusProvider = instance.provider
 
-        // patch the chainChanged event
-        const on = torusProvider.on.bind(torusProvider)
-        torusProvider.on = (event, listener) => {
-          on(event, val => {
-            if (event === 'chainChanged') {
-              listener(`0x${(val as number).toString(16)}`)
-              return
-            }
-
-            listener(val)
-          })
-
-          return torusProvider
-        }
-
         const provider = createEIP1193Provider(torusProvider, {
           eth_requestAccounts: async () => {
             try {


### PR DESCRIPTION
### Description
The Torus provider `chainChanged` event now returns a hex encoded string rather than decimal. The current patching logic does not handle hex encoded `chainId`. There is no need for the patch now, so this PR removes it.

Fixes #1446 

### Checklist
- [x] The version field in `package.json` of the package you have made changes in is incremented following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn file-check`, `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks