### PR TITLE
Feature: Auto Connect Last Wallet Option

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -129,12 +129,16 @@ An object that allows for customization of the Connect Modal and accepts the typ
 ```typescript
 type ConnectModalOptions = {
   showSidebar?: boolean
-  showSidebar?: boolean
   /**
    * Disabled close of the connect modal with background click and
    * hides the close button forcing an action from the connect modal
    */
   disableClose?: boolean // defaults to false
+  /**If set to true, the last connected wallet will store in local storage.
+   * Then on init, onboard will try to reconnect to that wallet with
+   * no modals displayed
+   */
+  autoConnectLastWallet?: boolean // defaults to false
 }
 ```
 
@@ -476,45 +480,16 @@ connectWallet()
 
 ### Auto Selecting a Wallet
 
-A common UX pattern is to remember the wallet(s) that a user has previously connected by storing them in localStorage and then automatically selecting them for the user next time they visit your app.
-You could enable this in your app by first syncing the `wallets` array to localStorage:
+A common UX pattern is to remember the last wallet that a user has previously connected by storing it in localStorage and then automatically selecting them for the user next time they visit your app.
+You can enable this in your app by using the `autoConnectLastWallet` parameter when initializing and Onboard will take care of it:
 
 ```javascript
-const walletsSub = onboard.state.select('wallets')
-const { unsubscribe } = walletsSub.subscribe(wallets => {
-  const connectedWallets = wallets.map(({ label }) => label)
-  window.localStorage.setItem(
-    'connectedWallets',
-    JSON.stringify(connectedWallets)
-  )
+const onboard = Onboard({
+  // ... other options
+  connect: {
+    autoConnectLastWallet: true
+  }
 })
-
-// Don't forget to unsubscribe when your app or component un mounts to prevent memory leaks
-// unsubscribe()
-```
-
-Now that you have the most recent wallets connected saved in local storage, you can auto select those wallet(s) when your app loads:
-
-```javascript
-const previouslyConnectedWallets = JSON.parse(
-  window.localStorage.getItem('connectedWallets')
-)
-
-if (previouslyConnectedWallets) {
-  // Connect the most recently connected wallet (first in the array)
-  await onboard.connectWallet({ autoSelect: previouslyConnectedWallets[0] })
-
-  // You can also auto connect "silently" and disable all onboard modals to avoid them flashing on page load
-  await onboard.connectWallet({
-    autoSelect: { label: previouslyConnectedWallets[0], disableModals: true }
-  })
-
-  // OR - loop through and initiate connection for all previously connected wallets
-  // note: This UX might not be great as the user may need to login to each wallet one after the other
-  // for (walletLabel in previouslyConnectedWallets) {
-  //   await onboard.connectWallet({ autoSelect: walletLabel })
-  // }
-}
 ```
 
 ## Disconnecting a Wallet

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.14.1",
+  "version": "2.15.0-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -31,7 +31,8 @@ export const APP_INITIAL_STATE: AppState = {
 }
 
 export const STORAGE_KEYS = {
-  TERMS_AGREEMENT: 'onboard.js:agreement'
+  TERMS_AGREEMENT: 'onboard.js:agreement',
+  LAST_CONNECTED_WALLET: 'onboard.js:last_connected_wallet'
 }
 
 export const MOBILE_WINDOW_WIDTH = 768

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,10 +7,10 @@ import { reset$, wallets$ } from './streams.js'
 import initI18N from './i18n/index.js'
 import App from './views/Index.svelte'
 import type { InitOptions, Notify } from './types.js'
-import { APP_INITIAL_STATE } from './constants.js'
+import { APP_INITIAL_STATE, STORAGE_KEYS } from './constants.js'
 import { configuration, updateConfiguration } from './configuration.js'
 import updateBalances from './update-balances.js'
-import { chainIdToHex } from './utils.js'
+import { chainIdToHex, getLocalStore } from './utils.js'
 import { preflightNotifications } from './preflight-notifications.js'
 
 import {
@@ -225,6 +225,18 @@ function init(options: InitOptions): OnboardAPI {
   }
 
   theme && updateTheme(theme)
+
+  // handle auto connection of last wallet
+  if (connect && connect.autoConnectLastWallet) {
+    const lastConnectedWallet = getLocalStore(
+      STORAGE_KEYS.LAST_CONNECTED_WALLET
+    )
+
+    lastConnectedWallet &&
+      API.connectWallet({
+        autoSelect: { label: lastConnectedWallet, disableModals: true }
+      })
+  }
 
   return API
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -64,7 +64,7 @@ export interface InitOptions {
    */
   transactionPreview?: TransactionPreviewAPI
   /**
-   * Custom or predefined theme for Web3Onboard 
+   * Custom or predefined theme for Web3Onboard
    * BuiltInThemes: ['default', 'dark', 'light', 'system']
    * or customize with a ThemingMap object.
    */
@@ -181,6 +181,11 @@ export type ConnectModalOptions = {
    * Defaults to false
    */
   disableClose?: boolean
+  /**If set to true, the last connected wallet will store in local storage.
+   * Then on init, onboard will try to reconnect to that wallet with
+   * no modals displayed
+   */
+  autoConnectLastWallet?: boolean
 }
 
 export type CommonPositions =

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -263,3 +263,28 @@ export const defaultNotifyEventStyles: Record<string, NotifyEventStyles> = {
 
 export const wait = (time: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, time))
+
+export function getLocalStore(key: string): string | null {
+  try {
+    const result = localStorage.getItem(key)
+    return result
+  } catch (error) {
+    return null
+  }
+}
+
+export function setLocalStore(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value)
+  } catch (error) {
+    return
+  }
+}
+
+export function delLocalStore(key: string): void {
+  try {
+    localStorage.removeItem(key)
+  } catch (error) {
+    return
+  }
+}

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -172,7 +172,8 @@ const accountCenter = Joi.object({
 
 const connectModalOptions = Joi.object({
   showSidebar: Joi.boolean(),
-  disableClose: Joi.boolean()
+  disableClose: Joi.boolean(),
+  autoConnectLastWallet: Joi.boolean()
 })
 
 const containerElements = Joi.object({

--- a/packages/core/src/views/connect/Agreement.svelte
+++ b/packages/core/src/views/connect/Agreement.svelte
@@ -2,13 +2,15 @@
   import { _ } from 'svelte-i18n'
   import { STORAGE_KEYS } from '../../constants.js'
   import { configuration } from '../../configuration.js'
+  import { delLocalStore, getLocalStore, setLocalStore } from '../../utils'
+
   export let agreed: boolean
 
   const {
     terms: termsAgreed,
     privacy: privacyAgreed,
     version: versionAgreed
-  } = JSON.parse(localStorage.getItem(STORAGE_KEYS.TERMS_AGREEMENT) || '{}')
+  } = JSON.parse(getLocalStore(STORAGE_KEYS.TERMS_AGREEMENT) || '{}')
 
   const blankAgreement = { termsUrl: '', privacyUrl: '', version: '' }
   const { appMetadata } = configuration
@@ -25,7 +27,7 @@
   agreed = !showTermsOfService
 
   $: if (agreed) {
-    localStorage.setItem(
+    setLocalStore(
       STORAGE_KEYS.TERMS_AGREEMENT,
       JSON.stringify({
         version,
@@ -34,7 +36,7 @@
       })
     )
   } else if (agreed === false) {
-    localStorage.removeItem(STORAGE_KEYS.TERMS_AGREEMENT)
+    delLocalStore(STORAGE_KEYS.TERMS_AGREEMENT)
   }
 </script>
 

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
   import { ProviderRpcErrorCode, WalletModule } from '@web3-onboard/common'
   import EventEmitter from 'eventemitter3'
+  import { BigNumber } from 'ethers'
   import { _ } from 'svelte-i18n'
   import en from '../../i18n/en.json'
   import { listenAccountsChanged, selectAccounts } from '../../provider.js'
   import { state } from '../../store/index.js'
   import { connectWallet$, onDestroy$ } from '../../streams.js'
   import { addWallet, updateAccount } from '../../store/actions.js'
-  import { validEnsChain, isSVG } from '../../utils.js'
+  import { validEnsChain, isSVG, setLocalStore } from '../../utils.js'
   import CloseButton from '../shared/CloseButton.svelte'
   import Modal from '../shared/Modal.svelte'
   import Agreement from './Agreement.svelte'
@@ -18,8 +19,9 @@
   import Sidebar from './Sidebar.svelte'
   import { configuration } from '../../configuration.js'
   import { getBNMulitChainSdk } from '../../services.js'
+  import { MOBILE_WINDOW_WIDTH, STORAGE_KEYS } from '../../constants.js'
+  import { defaultBnIcon } from '../../icons/index.js'
 
-  import { BigNumber } from 'ethers'
   import {
     BehaviorSubject,
     distinctUntilChanged,
@@ -30,8 +32,6 @@
     take,
     takeUntil
   } from 'rxjs'
-
-  import { defaultBnIcon } from '../../icons/index.js'
 
   import {
     getChainId,
@@ -48,7 +48,6 @@
     WalletState,
     WalletWithLoadingIcon
   } from '../../types.js'
-  import { MOBILE_WINDOW_WIDTH } from '../../constants.js'
 
   export let autoSelect: ConnectOptions['autoSelect']
 
@@ -224,6 +223,11 @@
         return
       }
 
+      // store last connected wallet
+      if (state.get().connect.autoConnectLastWallet) {
+        setLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET, label)
+      }
+
       const chain = await getChainId(provider)
 
       if (state.get().notify.enabled) {
@@ -382,7 +386,10 @@
 <style>
   .container {
     /* component values */
-    --background-color: var(--onboard-main-scroll-container-background, var(--w3o-background-color));
+    --background-color: var(
+      --onboard-main-scroll-container-background,
+      var(--w3o-background-color)
+    );
     --foreground-color: var(--w3o-foreground-color);
     --text-color: var(--onboard-connect-text-color, var(--w3o-text-color));
     --border-color: var(--w3o-border-color, var(--gray-200));

--- a/packages/demo/src/App.svelte
+++ b/packages/demo/src/App.svelte
@@ -131,7 +131,7 @@
 
   const trezorOptions = {
     email: 'test@test.com',
-    appUrl: 'https://www.blocknative.com',
+    appUrl: 'https://www.blocknative.com'
     // containerElement: '#sample-container-el'
   }
   const trezor = trezorModule(trezorOptions)
@@ -231,9 +231,10 @@
         rpcUrl: 'https://rpc.ankr.com/arbitrum'
       }
     ],
-    // connect: {
-    //   disableClose: true
-    // },
+    connect: {
+      // disableClose: true,
+      autoConnectLastWallet: true
+    },
     appMetadata: {
       name: 'Blocknative',
       // icon: blocknativeIcon,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,7 +62,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.14.1",
+    "@web3-onboard/core": "^2.15.0-alpha.1",
     "@web3-onboard/common": "^2.2.3",
     "use-sync-external-store": "1.0.0"
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.6.1",
+  "version": "2.6.2-alpha.1",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -63,7 +63,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.2.3",
-    "@web3-onboard/core": "^2.14.1",
+    "@web3-onboard/core": "^2.15.0-alpha.1",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.5.1",
+  "version": "2.5.2-alpha.1",
   "description": "A collection of Vue Composables for integrating Web3-Onboard in to a Vue or Nuxt project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
### Description
This PR implements a commonly requested feature for auto connecting a wallet that has been previously connected. There is now a `autoConnectLastWallet` option which can be set during initialization:

```javascript
const onboard = Onboard({
  // ... other options
  connect: {
    autoConnectLastWallet: true
  }
})
```

Also implemented in this PR is error handling for accessing `localStorage` to handle when browsers have blocked access (eg TOR browser).

### Checklist
- [x] The version field in `package.json` of the package you have made changes in is incremented following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn file-check`, `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks