### PR TITLE
Add XDEFI module and injected to docs site

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -78,6 +78,7 @@
     "@web3-onboard/uauth": "^2.0.1",
     "@web3-onboard/walletconnect": "^2.2.1",
     "@web3-onboard/web3auth": "^2.1.4",
+    "@web3-onboard/xdefi": "^2.0.0",
     "animejs": "^3.2.1",
     "ethers": "^5.7.0"
   }

--- a/docs/src/lib/services/onboard.js
+++ b/docs/src/lib/services/onboard.js
@@ -52,6 +52,7 @@ const intiOnboard = async (theme) => {
   const { default: web3authModule } = await import('@web3-onboard/web3auth')
   const { default: uauthModule } = await import('@web3-onboard/uauth')
   const { default: trustModule } = await import('@web3-onboard/trust')
+  const { default: xdefiModule } = await import('@web3-onboard/xdefi')
   const INFURA_ID = '8b60d52405694345a99bcb82e722e0af'
 
   const injected = injectedModule()
@@ -68,6 +69,7 @@ const intiOnboard = async (theme) => {
   const tally = tallyModule()
   const torus = torusModule()
   const trust = trustModule()
+  const xdefi = xdefiModule()
 
   const portis = portisModule({
     apiKey: 'b2b7586f-2b1e-4c30-a7fb-c2d1533b153b'
@@ -110,6 +112,7 @@ const intiOnboard = async (theme) => {
       gnosis,
       uauth,
       tally,
+      xdefi,
       torus,
       sequence,
       web3auth,

--- a/docs/src/routes/docs/[...4]wallets/injected.md
+++ b/docs/src/routes/docs/[...4]wallets/injected.md
@@ -292,9 +292,9 @@ const injected = injectedModule({
 - Meetone - _Mobile_
 - Mykey - _Mobile_
 - Ownbit - _Mobile_
+- xDefi - _Desktop & Mobile_
 - Tokenpocket - _Desktop & Mobile_
 - TP - _Mobile_
-- xDefi - _Desktop & Mobile_
 - 1inch - _Mobile_
 - Tokenary - _Mobile_
 - GameStop - _Desktop_

--- a/docs/src/routes/docs/[...4]wallets/xdefi.md
+++ b/docs/src/routes/docs/[...4]wallets/xdefi.md
@@ -1,0 +1,47 @@
+
+# XDEFI
+
+## Wallet module for connecting XDEFI to web3-onboard
+
+See [XDEFI Wallet Developer Docs](https://sdk.xdefi.io/)
+
+## Install
+
+<Tabs values={['yarn', 'npm']}>
+<TabPanel value="yarn">
+
+```sh copy
+yarn add @web3-onboard/core @web3-onboard/xdefi
+```
+
+  </TabPanel>
+  <TabPanel value="npm">
+
+```sh copy
+npm install @web3-onboard/core @web3-onboard/xdefi
+```
+
+  </TabPanel>
+</Tabs>
+
+
+## Usage
+
+```typescript
+import Onboard from '@web3-onboard/core'
+import xdefiWalletModule from '@web3-onboard/xdefi'
+
+// initialize the module with options
+const xdefiWalletSdk = xdefiWalletModule()
+
+const onboard = Onboard({
+  // ... other Onboard options
+  wallets: [
+    xdefiWalletSdk()
+    //... other wallets
+  ]
+})
+
+const connectedWallets = await onboard.connectWallet()
+console.log(connectedWallets)
+```

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3206,6 +3206,13 @@
     "@web3auth/base" "^3.3.0"
     "@web3auth/modal" "^3.3.0"
 
+"@web3-onboard/xdefi@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/xdefi/-/xdefi-2.0.0.tgz#1adff4d798688d18616cfc8d78150fbe47f1757a"
+  integrity sha512-sgqhXUSO6dIvAmzKwD/ygCLtpkDgeLZ3Th8JkmV5t8wsYWj26FPuJFT0LNy4yVXSg4psFzsYcWb23BLdlTLvog==
+  dependencies:
+    "@web3-onboard/common" "^2.2.3"
+
 "@web3auth/base-evm-adapter@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@web3auth/base-evm-adapter/-/base-evm-adapter-3.3.0.tgz#ab8575ac5d05dfe055e52500b61691cefdd6268f"
@@ -3931,17 +3938,7 @@ bnb-javascript-sdk-nobroadcast@^2.16.14:
     uuid "^3.3.2"
     websocket-stream "^5.5.0"
 
-bnc-sdk@^4.6.6:
-  version "4.6.6"
-  resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-4.6.6.tgz#ef5501a0c68014efae24d00d2e3fb706318fa00d"
-  integrity sha512-cpavy/WBQrkw5PZpnuUAvxzj/RjmP1vSldOEG+nonf7n/4sykScDO6KrJN2oVhEMaxHOqOVf2rOugSL5t515eA==
-  dependencies:
-    crypto-es "^1.2.2"
-    nanoid "^3.3.1"
-    rxjs "^6.6.3"
-    sturdy-websocket "^0.1.12"
-
-bnc-sdk@^4.6.7:
+bnc-sdk@^4.6.6, bnc-sdk@^4.6.7:
   version "4.6.7"
   resolved "https://registry.yarnpkg.com/bnc-sdk/-/bnc-sdk-4.6.7.tgz#138a22e04c95c2c697fb836092358d21957e2114"
   integrity sha512-jIQ6cmeRBgvH/YDLuYRr2+kxDGcAAi0SOvjlO5nQ5cWdbslw+ASWftd1HmxiVLNCiwEH5bSc/t8a0agZ5njTUQ==

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -2969,10 +2969,10 @@
     ethers "5.5.4"
     joi "^17.6.1"
 
-"@web3-onboard/core@^2.15.1-alpha.1":
-  version "2.15.1-alpha.1"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.15.1-alpha.1.tgz#a6c241ba7eb84f40547e57b8192ecd46759ec5ad"
-  integrity sha512-CrAj0WkBxO52j2JUs5YFIbvfwyrUoWXO7B3QOG6VrQ9w4HRXO5lVBsD2RYMSA5fTbAbRZ7VwPiHCdmQ/ztKYLg==
+"@web3-onboard/core@^2.15.2-alpha.1":
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/core/-/core-2.15.2.tgz#9156f3c0a39dfb9aa8963a8ef4d8cf11bd8b5695"
+  integrity sha512-5p7rW6xNpljAq85kCcU5O/MKSR7uDG4V3EixwfwvNSITHejtjpfGmcUPFW7pYI/J+PQ3Z/u1ThMRDoD2tfjevA==
   dependencies:
     "@unstoppabledomains/resolution" "^8.0"
     "@web3-onboard/common" "^2.2.3"
@@ -3138,10 +3138,10 @@
     "@toruslabs/torus-embed" "1.38.2"
     "@web3-onboard/common" "^2.2.3"
 
-"@web3-onboard/transaction-preview@^2.0.3-alpha.1":
-  version "2.0.3-alpha.1"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/transaction-preview/-/transaction-preview-2.0.3-alpha.1.tgz#b8945c3b785dc1e0281709c01b464fe45aea1570"
-  integrity sha512-iJZtvGcYh3ZbmTzaNRAUWKmX4VwgbgaKbmlYCdmeOvNjB7fZykzqr9CXbGwwVmfI3xA7zT17hP5M0WjGFyuDFA==
+"@web3-onboard/transaction-preview@^2.0.4-alpha.1":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/transaction-preview/-/transaction-preview-2.0.4.tgz#c2d5dc55cf1602e9150c70238fc38a573ae580c7"
+  integrity sha512-GWnyPzQh0/7qVE8TDiehILqAlSsoodlUGq6FCuyIU2abaBDhssODxX+s9MLrSF0SlV8jniJ+KoG3ir1Q1chQTQ==
   dependencies:
     "@web3-onboard/common" "^2.2.3"
     bnc-sdk "^4.6.7"


### PR DESCRIPTION
### Description
XDEFI module was previously missing from the docs site and is added in this PR

<img width="1146" alt="Screen Shot 2023-02-22 at 10 20 31 AM" src="https://user-images.githubusercontent.com/24457880/220706330-264043ba-e5e1-4559-802a-2654444b7072.png">
<img width="1925" alt="Screen Shot 2023-02-22 at 10 01 10 AM" src="https://user-images.githubusercontent.com/24457880/220706336-bda99c22-0067-4bf6-bee6-19c964221cb6.png">


### Checklist
- [x] The version field in `package.json` of the package you have made changes in is incremented following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn file-check`, `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks

