### PR TITLE
[core, react, vue]: Fix - Remove wallet from localStorage when disconnect is called with the primary wallet label

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.15.4",
+  "version": "2.15.5-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/disconnect.ts
+++ b/packages/core/src/disconnect.ts
@@ -4,7 +4,7 @@ import { removeWallet } from './store/actions.js'
 import { disconnectWallet$ } from './streams.js'
 import type { DisconnectOptions, WalletState } from './types.js'
 import { validateDisconnectOptions } from './validation.js'
-import { delLocalStore } from './utils'
+import { delLocalStore, getLocalStore } from './utils'
 import { STORAGE_KEYS } from './constants'
 
 async function disconnect(options: DisconnectOptions): Promise<WalletState[]> {
@@ -34,7 +34,10 @@ async function disconnect(options: DisconnectOptions): Promise<WalletState[]> {
 
   disconnectWallet$.next(label)
   removeWallet(label)
-  delLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
+
+  if (getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET) === label) {
+    delLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
+  }
 
   return state.get().wallets
 }

--- a/packages/core/src/disconnect.ts
+++ b/packages/core/src/disconnect.ts
@@ -4,6 +4,8 @@ import { removeWallet } from './store/actions.js'
 import { disconnectWallet$ } from './streams.js'
 import type { DisconnectOptions, WalletState } from './types.js'
 import { validateDisconnectOptions } from './validation.js'
+import { delLocalStore } from './utils'
+import { STORAGE_KEYS } from './constants'
 
 async function disconnect(options: DisconnectOptions): Promise<WalletState[]> {
   const error = validateDisconnectOptions(options)
@@ -32,6 +34,7 @@ async function disconnect(options: DisconnectOptions): Promise<WalletState[]> {
 
   disconnectWallet$.next(label)
   removeWallet(label)
+  delLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
 
   return state.get().wallets
 }

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
     "webpack-dev-server": "4.7.4"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.15.4",
+    "@web3-onboard/core": "^2.15.5-alpha.1",
     "@web3-onboard/coinbase": "^2.1.4",
     "@web3-onboard/transaction-preview": "^2.0.4",
     "@web3-onboard/dcent": "^2.2.3",

--- a/packages/demo/src/App.svelte
+++ b/packages/demo/src/App.svelte
@@ -243,7 +243,7 @@
     ],
     connect: {
       // disableClose: true,
-      disableUDResolution: true,
+      // disableUDResolution: true,
       autoConnectLastWallet: true
     },
     appMetadata: {

--- a/packages/demo/src/App.svelte
+++ b/packages/demo/src/App.svelte
@@ -243,7 +243,7 @@
     ],
     connect: {
       // disableClose: true,
-      // disableUDResolution: true,
+      disableUDResolution: true,
       autoConnectLastWallet: true
     },
     appMetadata: {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.6.5",
+  "version": "2.6.6-alpha.1",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,7 +62,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.15.4",
+    "@web3-onboard/core": "^2.15.5-alpha.1",
     "@web3-onboard/common": "^2.2.3",
     "use-sync-external-store": "1.0.0"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.5.5",
+  "version": "2.5.6-alpha.1",
   "description": "A collection of Vue Composables for integrating Web3-Onboard in to a Vue or Nuxt project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -63,7 +63,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.2.3",
-    "@web3-onboard/core": "^2.15.4",
+    "@web3-onboard/core": "^2.15.5-alpha.1",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
Remove wallet from localStorage when disconnect is called with the primary wallet label.

If a non-primary wallet is disconnected the localStorage will persist.

Closes: #1545 

### Checklist
- [x] The version field in `package.json` of the package you have made changes in is incremented following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] The box that allows repo maintainers to update this PR is checked
- [x] I tested locally to make sure this feature/fix works
- [x] I have run `yarn file-check`, `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [x] This PR passes the Circle CI checks
