### PR TITLE
[walletconnect-v2.3.1-alpha.1]: Update - walletConnect params to include `requiredChains` and updated WC deps

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -77,7 +77,7 @@
     "@web3-onboard/trezor": "^2.3.3",
     "@web3-onboard/trust": "^2.0.0",
     "@web3-onboard/uauth": "^2.0.1",
-    "@web3-onboard/walletconnect": "^2.3.1",
+    "@web3-onboard/walletconnect": "^2.3.1-alpha.1",
     "@web3-onboard/web3auth": "^2.1.4",
     "@web3-onboard/xdefi": "^2.0.0",
     "animejs": "^3.2.1",

--- a/docs/src/routes/docs/[...4]wallets/walletconnect.md
+++ b/docs/src/routes/docs/[...4]wallets/walletconnect.md
@@ -56,9 +56,10 @@ type WalletConnectOptions = {
        */
       version: 2
       /**
-       * List of Required Chain(s) ID for wallets to support in number format
+       * List of Required Chain(s) ID for wallets to support in number format 
+       * Hex is NOT CURRENTLY SUPPORTED for this property
        * Defaults to [1] - Ethereum
-       * The chains defined within the web3-onboard config will define the 
+       * The chains defined within the web3-onboard config will define the
        * optional chains for the WalletConnect module
        */
       requiredChains?: number[] | undefined

--- a/docs/src/routes/docs/[...4]wallets/walletconnect.md
+++ b/docs/src/routes/docs/[...4]wallets/walletconnect.md
@@ -56,8 +56,7 @@ type WalletConnectOptions = {
        */
       version: 2
       /**
-       * List of Required Chain(s) ID for wallets to support in number format 
-       * Hex is NOT CURRENTLY SUPPORTED for this property
+       * List of Required Chain(s) ID for wallets to support in number format (integer or hex)
        * Defaults to [1] - Ethereum
        * The chains defined within the web3-onboard config will define the
        * optional chains for the WalletConnect module

--- a/docs/src/routes/docs/[...4]wallets/walletconnect.md
+++ b/docs/src/routes/docs/[...4]wallets/walletconnect.md
@@ -55,6 +55,13 @@ type WalletConnectOptions = {
        * Defaults to version: 1 - this behavior will be deprecated after the WalletConnect v1 sunset
        */
       version: 2
+      /**
+       * List of Required Chain(s) ID for wallets to support in number format
+       * Defaults to [1] - Ethereum
+       * The chains defined within the web3-onboard config will define the 
+       * optional chains for the WalletConnect module
+       */
+      requiredChains?: number[] | undefined
     }
 )
 ```
@@ -106,4 +113,5 @@ console.log(connectedWallets)
 ```
 
 ## Build Environments
+
 For build env configurations and setups please see the Build Env section [here](/docs/modules/core#build-environments)

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -46,7 +46,7 @@
     "@web3-onboard/tallyho": "^2.0.2-alpha.1",
     "@web3-onboard/taho": "^2.0.0-alpha.1",
     "@web3-onboard/web3auth": "^2.1.4",
-    "@web3-onboard/walletconnect": "^2.3.1",
+    "@web3-onboard/walletconnect": "^2.3.1-alpha.1",
     "@web3-onboard/enkrypt": "^2.0.0",
     "@web3-onboard/mew-wallet": "^2.0.0",
     "@web3-onboard/xdefi": "^2.0.0",

--- a/packages/demo/src/App.svelte
+++ b/packages/demo/src/App.svelte
@@ -109,7 +109,8 @@
     projectId: 'f6bd6e2911b56f5ac3bc8b2d0e2d7ad5',
     qrcodeModalOptions: {
     mobileLinks: ['rainbow', 'metamask', 'argent', 'trust', 'imtoken', 'pillar']
-    }
+    },
+    requiredChains: [1]
   })
   const portis = portisModule({
     apiKey: 'b2b7586f-2b1e-4c30-a7fb-c2d1533b153b'

--- a/packages/walletconnect/README.md
+++ b/packages/walletconnect/README.md
@@ -41,8 +41,7 @@ type WalletConnectOptions = {
        */
       version: 2
       /**
-       * List of Required Chain(s) ID for wallets to support in number format 
-       * Hex is NOT CURRENTLY SUPPORTED for this property
+       * List of Required Chain(s) ID for wallets to support in number format (integer or hex)
        * Defaults to [1] - Ethereum
        * The chains defined within the web3-onboard config will define the
        * optional chains for the WalletConnect module

--- a/packages/walletconnect/README.md
+++ b/packages/walletconnect/README.md
@@ -7,6 +7,7 @@
 `npm i @web3-onboard/core @web3-onboard/walletconnect`
 
 ## Not all Wallets support WalletConnect V2 currently
+
 _For an up to date list please see the [WalletConnect Explorer](https://explorer.walletconnect.com/?version=2)_
 
 ## Options
@@ -39,6 +40,13 @@ type WalletConnectOptions = {
        * Defaults to version: 1 - this behavior will be deprecated after the WalletConnect v1 sunset
        */
       version: 2
+      /**
+       * List of Required Chain(s) ID for wallets to support in number format
+       * Defaults to [1] - Ethereum
+       * The chains defined within the web3-onboard config will define the
+       * optional chains for the WalletConnect module
+       */
+      requiredChains?: number[] | undefined
     }
 )
 ```
@@ -52,7 +60,7 @@ import walletConnectModule from '@web3-onboard/walletconnect'
 const wcV1InitOptions = {
   bridge: 'YOUR_CUSTOM_BRIDGE_SERVER',
   qrcodeModalOptions: {
-    mobileLinks: ['metamask', 'argent', 'trust',]
+    mobileLinks: ['metamask', 'argent', 'trust']
   },
   connectFirstChainId: true
 }

--- a/packages/walletconnect/README.md
+++ b/packages/walletconnect/README.md
@@ -41,7 +41,8 @@ type WalletConnectOptions = {
        */
       version: 2
       /**
-       * List of Required Chain(s) ID for wallets to support in number format
+       * List of Required Chain(s) ID for wallets to support in number format 
+       * Hex is NOT CURRENTLY SUPPORTED for this property
        * Defaults to [1] - Ethereum
        * The chains defined within the web3-onboard config will define the
        * optional chains for the WalletConnect module

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletconnect",
-  "version": "2.3.1",
+  "version": "2.3.1-alpha.1",
   "description": "WalletConnect SDK module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@ethersproject/providers": "^5.5.0",
-    "@walletconnect/ethereum-provider": "2.4.6",
+    "@walletconnect/ethereum-provider": "2.4.10",
     "@walletconnect/client": "^1.8.0",
     "@walletconnect/qrcode-modal": "^1.8.0",
     "@web3-onboard/common": "^2.2.3",

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -29,6 +29,13 @@ export type WalletConnectOptions = {
        * Defaults to version: 1 - this behavior will be deprecated after the WalletConnect v1 sunset
        */
       version: 2
+      /**
+       * List of Required Chain(s) ID for wallets to support in number format
+       * Defaults to [1] - Ethereum
+       * The chains defined within the web3-onboard config will define the 
+       * optional chains for the WalletConnect module
+       */
+      requiredChains?: number[] | undefined
     }
 )
 
@@ -41,7 +48,7 @@ export const isHexString = (value: string | number) => {
 }
 
 function walletConnect(options?: WalletConnectOptions): WalletInit {
-  const version = options?.version || 1
+  const version = options && options.version || 1
   return version === 1 ? v1(options) : v2(options)
 }
 

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -30,9 +30,10 @@ export type WalletConnectOptions = {
        */
       version: 2
       /**
-       * List of Required Chain(s) ID for wallets to support in number format
+       * List of Required Chain(s) ID for wallets to support in number format 
+       * Hex is NOT CURRENTLY SUPPORTED for this property
        * Defaults to [1] - Ethereum
-       * The chains defined within the web3-onboard config will define the 
+       * The chains defined within the web3-onboard config will define the
        * optional chains for the WalletConnect module
        */
       requiredChains?: number[] | undefined

--- a/packages/walletconnect/src/index.ts
+++ b/packages/walletconnect/src/index.ts
@@ -30,8 +30,7 @@ export type WalletConnectOptions = {
        */
       version: 2
       /**
-       * List of Required Chain(s) ID for wallets to support in number format 
-       * Hex is NOT CURRENTLY SUPPORTED for this property
+       * List of Required Chain(s) ID for wallets to support in number format (integer or hex)
        * Defaults to [1] - Ethereum
        * The chains defined within the web3-onboard config will define the
        * optional chains for the WalletConnect module

--- a/packages/walletconnect/src/v2.ts
+++ b/packages/walletconnect/src/v2.ts
@@ -69,8 +69,11 @@ function walletConnect(options?: WalletConnectOptions): WalletInit {
           options &&
           options.version === 2 &&
           Array.isArray(options.requiredChains) &&
-          options.requiredChains.length
-            ? options.requiredChains
+          options.requiredChains.length &&
+          options.requiredChains.every(num => !isNaN(num) )
+              // @ts-ignore
+              // Required as WC package does not support hex numbers
+            ? options.requiredChains.map(chainID => parseInt(chainID))
             : [1]
 
         const connector = await EthereumProvider.init({

--- a/packages/walletconnect/src/v2.ts
+++ b/packages/walletconnect/src/v2.ts
@@ -20,7 +20,7 @@ const methods = [
 
 function walletConnect(options?: WalletConnectOptions): WalletInit {
   const projectId =
-    options && options.version == 2 ? options.projectId : undefined
+    options && options.version === 2 ? options.projectId : undefined
   if (!projectId) {
     throw new Error(
       'WalletConnect requires a projectId. Please visit https://cloud.walletconnect.com to get one.'
@@ -64,10 +64,19 @@ function walletConnect(options?: WalletConnectOptions): WalletInit {
           return wcMetaData
         }
 
+        // default to mainnet
+        const requiredChains =
+          options &&
+          options.version === 2 &&
+          Array.isArray(options.requiredChains) &&
+          options.requiredChains.length
+            ? options.requiredChains
+            : [1]
+
         const connector = await EthereumProvider.init({
           projectId,
           metadata: getMetaData(),
-          chains: [1], // default to mainnet
+          chains: requiredChains, // default to mainnet
           optionalChains: chains.map(({ id }) => parseInt(id, 16)),
           optionalMethods: methods,
           rpcMap: chains
@@ -168,7 +177,7 @@ function walletConnect(options?: WalletConnectOptions): WalletInit {
                 })
             }
 
-            (() => {
+            ;(() => {
               const session = this.connector.session
               if (session) {
                 this.emit('accountsChanged', this.connector.accounts)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2961,6 +2961,28 @@
     "@walletconnect/types" "^1.8.0"
     "@walletconnect/utils" "^1.8.0"
 
+"@walletconnect/core@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.4.10.tgz#8975996b5c47d0d11a1187b3793215678c3ea3af"
+  integrity sha512-3ZVS07NS9+zG+Mw4MOxYhoJHwCSuIOrq+HuhaTLZZ+NswscZ+GwguF2fTsRNgk4jXkMJodaqUFxfPJeCVVcwHQ==
+  dependencies:
+    "@walletconnect/heartbeat" "1.2.0"
+    "@walletconnect/jsonrpc-provider" "1.0.9"
+    "@walletconnect/jsonrpc-utils" "^1.0.4"
+    "@walletconnect/jsonrpc-ws-connection" "1.0.10"
+    "@walletconnect/keyvaluestorage" "^1.0.2"
+    "@walletconnect/logger" "^2.0.1"
+    "@walletconnect/relay-api" "^1.0.9"
+    "@walletconnect/relay-auth" "^1.0.4"
+    "@walletconnect/safe-json" "^1.0.1"
+    "@walletconnect/time" "^1.0.2"
+    "@walletconnect/types" "2.4.10"
+    "@walletconnect/utils" "2.4.10"
+    events "^3.3.0"
+    lodash.isequal "4.5.0"
+    pino "7.11.0"
+    uint8arrays "^3.1.0"
+
 "@walletconnect/core@2.4.6":
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.4.6.tgz#77072bf3a523b8fa26c93d085af55a5ea88cb48a"
@@ -3051,6 +3073,22 @@
   dependencies:
     tslib "1.14.1"
 
+"@walletconnect/ethereum-provider@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.4.10.tgz#450167cf3fbfb7813189076f13c0c61e324f8c25"
+  integrity sha512-anD3inbmuIZgWJ7Km5QP6L/hjI8sK/3Q4WA+g8OlyHS2cqO9sPjYdbPUVnzVgwhTDbNDJr2AUNXmvpm2R0hq5Q==
+  dependencies:
+    "@walletconnect/jsonrpc-http-connection" "^1.0.4"
+    "@walletconnect/jsonrpc-provider" "^1.0.6"
+    "@walletconnect/jsonrpc-types" "^1.0.2"
+    "@walletconnect/jsonrpc-utils" "^1.0.4"
+    "@walletconnect/sign-client" "2.4.10"
+    "@walletconnect/types" "2.4.10"
+    "@walletconnect/universal-provider" "2.4.10"
+    "@walletconnect/utils" "2.4.10"
+    "@web3modal/standalone" "^2.2.0"
+    events "^3.3.0"
+
 "@walletconnect/ethereum-provider@2.4.6":
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.4.6.tgz#f05c76092ec3dda3667a6b7522518375eafc6e38"
@@ -3115,6 +3153,15 @@
     cross-fetch "^3.1.4"
     tslib "1.14.1"
 
+"@walletconnect/jsonrpc-provider@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.9.tgz#ce5ab64dce6a739110aef204ffeedd668ad343d8"
+  integrity sha512-8CwmiDW42F+F8Qct13lX2x4lJOsi0mNBtUln3VS6TpWioTaL1VfforC/8ULc3tHXv+SNWwAXn2lCZbDcYhdRcA==
+  dependencies:
+    "@walletconnect/jsonrpc-utils" "^1.0.6"
+    "@walletconnect/safe-json" "^1.0.1"
+    tslib "1.14.1"
+
 "@walletconnect/jsonrpc-provider@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.6.tgz#e91321ef523f1904e6634e7866a0f3c6f056d2cd"
@@ -3155,6 +3202,26 @@
     "@walletconnect/environment" "^1.0.1"
     "@walletconnect/jsonrpc-types" "^1.0.2"
     tslib "1.14.1"
+
+"@walletconnect/jsonrpc-utils@^1.0.6":
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.6.tgz#7fa58e6671247e64e189828103282e6258f5330f"
+  integrity sha512-snp0tfkjPiDLQp/jrBewI+9SM33GPV4+Gjgldod6XQ7rFyQ5FZjnBxUkY4xWH0+arNxzQSi6v5iDXjCjSaorpg==
+  dependencies:
+    "@walletconnect/environment" "^1.0.1"
+    "@walletconnect/jsonrpc-types" "^1.0.2"
+    tslib "1.14.1"
+
+"@walletconnect/jsonrpc-ws-connection@1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.10.tgz#04e04a7d8c70b27c386a1bdd9ff6511045da3c81"
+  integrity sha512-/tidvjfCXZuYugjF5fOswsNDPoMo9QRML3DFQ0dfNUarL4f5HGqu8NDGerr2n0+4MOX23GsT6Vv2POSwFbvgGw==
+  dependencies:
+    "@walletconnect/jsonrpc-utils" "^1.0.6"
+    "@walletconnect/safe-json" "^1.0.1"
+    events "^3.3.0"
+    tslib "1.14.1"
+    ws "^7.5.1"
 
 "@walletconnect/jsonrpc-ws-connection@^1.0.7":
   version "1.0.7"
@@ -3260,6 +3327,22 @@
   dependencies:
     tslib "1.14.1"
 
+"@walletconnect/sign-client@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.4.10.tgz#727072fcbf0c1f84c5370155f0feb7e711733ca4"
+  integrity sha512-8yNpRUVvkoFY5sdj7QbW1+g6QWgP8VLy1xVAqWkjLIiPieMA6IQcOpaEih9Bbq55oTOxjeWO9+E+V8/0bNXVvQ==
+  dependencies:
+    "@walletconnect/core" "2.4.10"
+    "@walletconnect/events" "^1.0.1"
+    "@walletconnect/heartbeat" "1.2.0"
+    "@walletconnect/jsonrpc-utils" "^1.0.4"
+    "@walletconnect/logger" "^2.0.1"
+    "@walletconnect/time" "^1.0.2"
+    "@walletconnect/types" "2.4.10"
+    "@walletconnect/utils" "2.4.10"
+    events "^3.3.0"
+    pino "7.11.0"
+
 "@walletconnect/sign-client@2.4.6":
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.4.6.tgz#6dff6a4683a44d5ac88c3f570c743016d814d878"
@@ -3302,6 +3385,18 @@
   dependencies:
     tslib "1.14.1"
 
+"@walletconnect/types@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.4.10.tgz#7f85a761b9d65e192d2f510ce858383f19a340f7"
+  integrity sha512-AvT3ynXXDXty94SadbjGrqqQA8vB1g9AchHZOakCY/Cfo5etpUFG3PfubWMC1FKe2FPk020nLkc2ghjNxHGGtw==
+  dependencies:
+    "@walletconnect/events" "^1.0.1"
+    "@walletconnect/heartbeat" "1.2.0"
+    "@walletconnect/jsonrpc-types" "^1.0.2"
+    "@walletconnect/keyvaluestorage" "^1.0.2"
+    "@walletconnect/logger" "^2.0.1"
+    events "^3.3.0"
+
 "@walletconnect/types@2.4.6":
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.4.6.tgz#45707ba774686f39a542c8cc1e9ca37c4a36691f"
@@ -3336,6 +3431,23 @@
     "@walletconnect/logger" "^2.0.1"
     events "^3.3.0"
 
+"@walletconnect/universal-provider@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.4.10.tgz#24696a2b9267d18a8a84008c5b42c8d5b917e4f0"
+  integrity sha512-KbRl3ivDGXtycp1qs/p8RvXz0f8VgG8k+NKpD6x9/ibnuuFLRt6UgriLHHCslJ9SSGuGHAeIaWs+kRRDKDNFXQ==
+  dependencies:
+    "@walletconnect/jsonrpc-http-connection" "^1.0.4"
+    "@walletconnect/jsonrpc-provider" "^1.0.6"
+    "@walletconnect/jsonrpc-types" "^1.0.2"
+    "@walletconnect/jsonrpc-utils" "^1.0.4"
+    "@walletconnect/logger" "^2.0.1"
+    "@walletconnect/sign-client" "2.4.10"
+    "@walletconnect/types" "2.4.10"
+    "@walletconnect/utils" "2.4.10"
+    eip1193-provider "1.0.1"
+    events "^3.3.0"
+    pino "7.11.0"
+
 "@walletconnect/universal-provider@2.4.6":
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.4.6.tgz#336ad48e2159f9a32fb2f8e5bb5ed29712ebbcbc"
@@ -3352,6 +3464,27 @@
     eip1193-provider "1.0.1"
     events "^3.3.0"
     pino "7.11.0"
+
+"@walletconnect/utils@2.4.10":
+  version "2.4.10"
+  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.4.10.tgz#1fbae7973008c06209ccf79797f732e44e97ac1c"
+  integrity sha512-mg01uaGY+DoT5yMVb7eL9zXdXZLRfkz85b63URa6QyfWD0Jbstmviutc5NU2YzzbIuekT3miL4cwPvi0MRklWA==
+  dependencies:
+    "@stablelib/chacha20poly1305" "1.0.1"
+    "@stablelib/hkdf" "1.0.1"
+    "@stablelib/random" "^1.0.2"
+    "@stablelib/sha256" "1.0.1"
+    "@stablelib/x25519" "^1.0.3"
+    "@walletconnect/jsonrpc-utils" "^1.0.4"
+    "@walletconnect/relay-api" "^1.0.9"
+    "@walletconnect/safe-json" "^1.0.1"
+    "@walletconnect/time" "^1.0.2"
+    "@walletconnect/types" "2.4.10"
+    "@walletconnect/window-getters" "^1.0.1"
+    "@walletconnect/window-metadata" "^1.0.1"
+    detect-browser "5.3.0"
+    query-string "7.1.1"
+    uint8arrays "^3.1.0"
 
 "@walletconnect/utils@2.4.6":
   version "2.4.6"
@@ -3426,6 +3559,18 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.1"
     tslib "1.14.1"
+
+"@web3-onboard/walletconnect@^2.3.1":
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.3.1.tgz#43396536070af6e04bb39b77e3056c0392367f09"
+  integrity sha512-SVya9DaycCv1IIeH3g5oRzpfudSvOOE70vsh30eY2tudfynhBZWqWXcKvtBimmudWc5WdWF+8r9OC5Ud89rFRQ==
+  dependencies:
+    "@ethersproject/providers" "^5.5.0"
+    "@walletconnect/client" "^1.8.0"
+    "@walletconnect/ethereum-provider" "2.4.6"
+    "@walletconnect/qrcode-modal" "^1.8.0"
+    "@web3-onboard/common" "^2.2.3"
+    rxjs "^7.5.2"
 
 "@web3-react/abstract-connector@^6.0.7":
   version "6.0.7"
@@ -3635,6 +3780,14 @@
     buffer "6.0.3"
     valtio "1.9.0"
 
+"@web3modal/core@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@web3modal/core/-/core-2.2.0.tgz#847459e1ab1766f312c39715270a7ca0fe831666"
+  integrity sha512-Kafg/KtK6S9x0Ofcaq9hj7dRK5/541nM+LnayPmHxx4fSrDgcM9YYhL12fI4BG1xGOJwkeZjgFOtS0qf123Cjw==
+  dependencies:
+    buffer "6.0.3"
+    valtio "1.9.0"
+
 "@web3modal/standalone@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@web3modal/standalone/-/standalone-2.1.1.tgz#e496e54af5ecf6e282ff7f287eebce7f1ac90bd2"
@@ -3643,12 +3796,30 @@
     "@web3modal/core" "2.1.1"
     "@web3modal/ui" "2.1.1"
 
+"@web3modal/standalone@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@web3modal/standalone/-/standalone-2.2.0.tgz#9f81ed976dd16bd795f902503065f75c9160eab3"
+  integrity sha512-cLFW4VamSJ7L4sM5OGmr1SHK3FgyLUMEaacvHsCA3XSvUF0LxbMC+N4uBsONrW4c0JyIjTdeii1GqG4B3jwn7Q==
+  dependencies:
+    "@web3modal/core" "2.2.0"
+    "@web3modal/ui" "2.2.0"
+
 "@web3modal/ui@2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@web3modal/ui/-/ui-2.1.1.tgz#300dceeee8a54be70aad74fb4a781ac22439eded"
   integrity sha512-0jRDxgPc/peaE5KgqnzzriXhdVu5xNyCMP5Enqdpd77VkknJIs7h16MYKidxgFexieyHpCOssWySsryWcP2sXA==
   dependencies:
     "@web3modal/core" "2.1.1"
+    lit "2.6.1"
+    motion "10.15.5"
+    qrcode "1.5.1"
+
+"@web3modal/ui@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@web3modal/ui/-/ui-2.2.0.tgz#2837da46706f1a3fcdf2f2c22e7ed029e235a3ab"
+  integrity sha512-jcV5C9AuMdsFdf6Ljsr0v2lInu8FJJyXcZPaMHkgYNIczzgMEpDE+UOA7hLnyCTUxM9R0AgRcgfTyMWb9H8Ssw==
+  dependencies:
+    "@web3modal/core" "2.2.0"
     lit "2.6.1"
     motion "10.15.5"
     qrcode "1.5.1"
@@ -11442,7 +11613,7 @@ uint8arrays@3.1.0:
   dependencies:
     multiformats "^9.4.2"
 
-uint8arrays@^3.0.0:
+uint8arrays@^3.0.0, uint8arrays@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-3.1.1.tgz#2d8762acce159ccd9936057572dade9459f65ae0"
   integrity sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2983,28 +2983,6 @@
     pino "7.11.0"
     uint8arrays "^3.1.0"
 
-"@walletconnect/core@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-2.4.6.tgz#77072bf3a523b8fa26c93d085af55a5ea88cb48a"
-  integrity sha512-IPjS3dZvLQ2ZjuVKpel6NHIoW1bkCayh5W8XFC7nhLj5GHou5Gy2FsGgGbRknvCEVWH85AlFKFAvLZCe+TJ2VA==
-  dependencies:
-    "@walletconnect/heartbeat" "1.2.0"
-    "@walletconnect/jsonrpc-provider" "^1.0.6"
-    "@walletconnect/jsonrpc-utils" "^1.0.4"
-    "@walletconnect/jsonrpc-ws-connection" "^1.0.7"
-    "@walletconnect/keyvaluestorage" "^1.0.2"
-    "@walletconnect/logger" "^2.0.1"
-    "@walletconnect/relay-api" "^1.0.9"
-    "@walletconnect/relay-auth" "^1.0.4"
-    "@walletconnect/safe-json" "^1.0.1"
-    "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.4.6"
-    "@walletconnect/utils" "2.4.6"
-    events "^3.3.0"
-    lodash.isequal "4.5.0"
-    pino "7.11.0"
-    uint8arrays "3.1.0"
-
 "@walletconnect/core@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@walletconnect/core/-/core-1.7.1.tgz#321c14d63af81241658b028022e0e5fa6dc7f374"
@@ -3087,22 +3065,6 @@
     "@walletconnect/universal-provider" "2.4.10"
     "@walletconnect/utils" "2.4.10"
     "@web3modal/standalone" "^2.2.0"
-    events "^3.3.0"
-
-"@walletconnect/ethereum-provider@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@walletconnect/ethereum-provider/-/ethereum-provider-2.4.6.tgz#f05c76092ec3dda3667a6b7522518375eafc6e38"
-  integrity sha512-o7UJ7EBzFSTqNAwGcVpqNv5qqaFW6Vi3nOoXPHtcrwYew8TKAcW/OQFHPcm0LeKfE15OvVI+GMHnPBRZ2Ih2RA==
-  dependencies:
-    "@walletconnect/jsonrpc-http-connection" "^1.0.4"
-    "@walletconnect/jsonrpc-provider" "^1.0.6"
-    "@walletconnect/jsonrpc-types" "^1.0.2"
-    "@walletconnect/jsonrpc-utils" "^1.0.4"
-    "@walletconnect/sign-client" "2.4.6"
-    "@walletconnect/types" "2.4.6"
-    "@walletconnect/universal-provider" "2.4.6"
-    "@walletconnect/utils" "2.4.6"
-    "@web3modal/standalone" "2.1.1"
     events "^3.3.0"
 
 "@walletconnect/events@^1.0.1":
@@ -3223,15 +3185,6 @@
     tslib "1.14.1"
     ws "^7.5.1"
 
-"@walletconnect/jsonrpc-ws-connection@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.7.tgz#48cdd875519602d14737c706f551ebcbb644179b"
-  integrity sha512-iEIWUAIQih0TDF+RRjExZL3jd84UWX/rvzAmQ6fZWhyBP/qSlxGrMuAwNhpk2zj6P8dZuf8sSaaNuWgXFJIa5A==
-  dependencies:
-    "@walletconnect/jsonrpc-utils" "^1.0.4"
-    "@walletconnect/safe-json" "^1.0.1"
-    ws "^7.5.1"
-
 "@walletconnect/keyvaluestorage@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.0.2.tgz#92f5ca0f54c1a88a093778842ce0c874d86369c8"
@@ -3343,23 +3296,6 @@
     events "^3.3.0"
     pino "7.11.0"
 
-"@walletconnect/sign-client@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@walletconnect/sign-client/-/sign-client-2.4.6.tgz#6dff6a4683a44d5ac88c3f570c743016d814d878"
-  integrity sha512-Dt5p4g105/1EFXFCTvdJiqtRGRgyWPzIJ8MSsTlYSoeJiTYwUC+mlBh4Y+Io/cxtc5hUuguaj0MyovIMiL4KkA==
-  dependencies:
-    "@walletconnect/core" "2.4.6"
-    "@walletconnect/events" "^1.0.1"
-    "@walletconnect/heartbeat" "1.2.0"
-    "@walletconnect/jsonrpc-provider" "^1.0.6"
-    "@walletconnect/jsonrpc-utils" "^1.0.4"
-    "@walletconnect/logger" "^2.0.1"
-    "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.4.6"
-    "@walletconnect/utils" "2.4.6"
-    events "^3.3.0"
-    pino "7.11.0"
-
 "@walletconnect/socket-transport@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@walletconnect/socket-transport/-/socket-transport-1.7.1.tgz#cc4c8dcf21c40b805812ecb066b2abb156fdb146"
@@ -3389,18 +3325,6 @@
   version "2.4.10"
   resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.4.10.tgz#7f85a761b9d65e192d2f510ce858383f19a340f7"
   integrity sha512-AvT3ynXXDXty94SadbjGrqqQA8vB1g9AchHZOakCY/Cfo5etpUFG3PfubWMC1FKe2FPk020nLkc2ghjNxHGGtw==
-  dependencies:
-    "@walletconnect/events" "^1.0.1"
-    "@walletconnect/heartbeat" "1.2.0"
-    "@walletconnect/jsonrpc-types" "^1.0.2"
-    "@walletconnect/keyvaluestorage" "^1.0.2"
-    "@walletconnect/logger" "^2.0.1"
-    events "^3.3.0"
-
-"@walletconnect/types@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@walletconnect/types/-/types-2.4.6.tgz#45707ba774686f39a542c8cc1e9ca37c4a36691f"
-  integrity sha512-0ck2VvTRT4pTMQbop2Dku8YuOdNhebyJlXjtHN4naFgu73rXiw7Yml4N4hKjV4cwJoOBepWD2f9Dvl9cDFQ/Wg==
   dependencies:
     "@walletconnect/events" "^1.0.1"
     "@walletconnect/heartbeat" "1.2.0"
@@ -3448,23 +3372,6 @@
     events "^3.3.0"
     pino "7.11.0"
 
-"@walletconnect/universal-provider@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@walletconnect/universal-provider/-/universal-provider-2.4.6.tgz#336ad48e2159f9a32fb2f8e5bb5ed29712ebbcbc"
-  integrity sha512-FvuCCoQ00kYK3M6wYpaK9goCTa8kK5DQPTrsXYeitfXcJccQHxJahpEzIadLc6sj5+uK06WuLGGSObfpjSG3IA==
-  dependencies:
-    "@walletconnect/jsonrpc-http-connection" "^1.0.4"
-    "@walletconnect/jsonrpc-provider" "^1.0.6"
-    "@walletconnect/jsonrpc-types" "^1.0.2"
-    "@walletconnect/jsonrpc-utils" "^1.0.4"
-    "@walletconnect/logger" "^2.0.1"
-    "@walletconnect/sign-client" "2.4.6"
-    "@walletconnect/types" "2.4.6"
-    "@walletconnect/utils" "2.4.6"
-    eip1193-provider "1.0.1"
-    events "^3.3.0"
-    pino "7.11.0"
-
 "@walletconnect/utils@2.4.10":
   version "2.4.10"
   resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.4.10.tgz#1fbae7973008c06209ccf79797f732e44e97ac1c"
@@ -3485,27 +3392,6 @@
     detect-browser "5.3.0"
     query-string "7.1.1"
     uint8arrays "^3.1.0"
-
-"@walletconnect/utils@2.4.6":
-  version "2.4.6"
-  resolved "https://registry.yarnpkg.com/@walletconnect/utils/-/utils-2.4.6.tgz#2bd192bfcc019d19929be2881f8e4f54fc9b56a0"
-  integrity sha512-SowRdiR3TTGeb3ikMP7ucOafgmu58Nh1pCjCff2666gQjVzT9qO1Y9aJ7eS3g3URJtLGzYCEIYohnUYOidvpgA==
-  dependencies:
-    "@stablelib/chacha20poly1305" "1.0.1"
-    "@stablelib/hkdf" "1.0.1"
-    "@stablelib/random" "^1.0.2"
-    "@stablelib/sha256" "1.0.1"
-    "@stablelib/x25519" "^1.0.3"
-    "@walletconnect/jsonrpc-utils" "^1.0.4"
-    "@walletconnect/relay-api" "^1.0.9"
-    "@walletconnect/safe-json" "^1.0.1"
-    "@walletconnect/time" "^1.0.2"
-    "@walletconnect/types" "2.4.6"
-    "@walletconnect/window-getters" "^1.0.1"
-    "@walletconnect/window-metadata" "^1.0.1"
-    detect-browser "5.3.0"
-    query-string "7.1.1"
-    uint8arrays "3.1.0"
 
 "@walletconnect/utils@^1.7.1":
   version "1.7.1"
@@ -3559,18 +3445,6 @@
   dependencies:
     "@walletconnect/window-getters" "^1.0.1"
     tslib "1.14.1"
-
-"@web3-onboard/walletconnect@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.3.1.tgz#43396536070af6e04bb39b77e3056c0392367f09"
-  integrity sha512-SVya9DaycCv1IIeH3g5oRzpfudSvOOE70vsh30eY2tudfynhBZWqWXcKvtBimmudWc5WdWF+8r9OC5Ud89rFRQ==
-  dependencies:
-    "@ethersproject/providers" "^5.5.0"
-    "@walletconnect/client" "^1.8.0"
-    "@walletconnect/ethereum-provider" "2.4.6"
-    "@walletconnect/qrcode-modal" "^1.8.0"
-    "@web3-onboard/common" "^2.2.3"
-    rxjs "^7.5.2"
 
 "@web3-react/abstract-connector@^6.0.7":
   version "6.0.7"
@@ -3772,14 +3646,6 @@
     "@web3auth/base-evm-adapter" "^3.3.0"
     "@web3auth/ethereum-provider" "^3.3.0"
 
-"@web3modal/core@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@web3modal/core/-/core-2.1.1.tgz#e1ebe8faaae6e4b74df911fd5ac6023f280b12c1"
-  integrity sha512-GAZAvfkPHoX2/fghQmf+y36uDspk9wBJxG7qLPUNTHzvIfRoNHWbTt3iEvRdPmUZwbTGDn1jvz9z0uU67gvZdw==
-  dependencies:
-    buffer "6.0.3"
-    valtio "1.9.0"
-
 "@web3modal/core@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@web3modal/core/-/core-2.2.0.tgz#847459e1ab1766f312c39715270a7ca0fe831666"
@@ -3788,14 +3654,6 @@
     buffer "6.0.3"
     valtio "1.9.0"
 
-"@web3modal/standalone@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@web3modal/standalone/-/standalone-2.1.1.tgz#e496e54af5ecf6e282ff7f287eebce7f1ac90bd2"
-  integrity sha512-K06VkZqltLIBKpnLeM2oszRDSdLnwXJWCcItWEOkH4LDFQIiq8lSeLhcamuadRxRKF4ZyTSLHHJ5MFcMfZEHQQ==
-  dependencies:
-    "@web3modal/core" "2.1.1"
-    "@web3modal/ui" "2.1.1"
-
 "@web3modal/standalone@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@web3modal/standalone/-/standalone-2.2.0.tgz#9f81ed976dd16bd795f902503065f75c9160eab3"
@@ -3803,16 +3661,6 @@
   dependencies:
     "@web3modal/core" "2.2.0"
     "@web3modal/ui" "2.2.0"
-
-"@web3modal/ui@2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@web3modal/ui/-/ui-2.1.1.tgz#300dceeee8a54be70aad74fb4a781ac22439eded"
-  integrity sha512-0jRDxgPc/peaE5KgqnzzriXhdVu5xNyCMP5Enqdpd77VkknJIs7h16MYKidxgFexieyHpCOssWySsryWcP2sXA==
-  dependencies:
-    "@web3modal/core" "2.1.1"
-    lit "2.6.1"
-    motion "10.15.5"
-    qrcode "1.5.1"
 
 "@web3modal/ui@2.2.0":
   version "2.2.0"
@@ -11605,13 +11453,6 @@ typescript@^4.6.2:
   version "4.6.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.4.tgz#caa78bbc3a59e6a5c510d35703f6a09877ce45e9"
   integrity sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==
-
-uint8arrays@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-3.1.0.tgz#8186b8eafce68f28bd29bd29d683a311778901e2"
-  integrity sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==
-  dependencies:
-    multiformats "^9.4.2"
 
 uint8arrays@^3.0.0, uint8arrays@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
### Description
This PR updates the `@walletconnect/ethereum-provider` packages to the latest and add a configurable `requiredChains` prop to the WC v2 initialization that defaults to `[1]`
This will allow dapps to define the required chains for supported wallets and was requested by @hlopes-ledger  one of the lead Ledger devs.
Documentation updates included!
```typescript
      /**
       * List of Required Chain(s) ID for wallets to support in number format 
       * Hex is NOT CURRENTLY SUPPORTED for this property
       * Defaults to [1] - Ethereum
       * The chains defined within the web3-onboard config will define the
       * optional chains for the WalletConnect module
       */
      requiredChains?: number[] | undefined
```

### Checklist
- [ ] The version field in `package.json` of the package you have made changes in is incremented following [semantic versioning](https://semver.org/) and using alpha release tagging
- [ ] The box that allows repo maintainers to update this PR is checked
- [ ] I tested locally to make sure this feature/fix works
- [ ] I have run `yarn file-check`, `yarn type-check` & `yarn build` to confirm there are not any associated errors
- [ ] This PR passes the Circle CI checks

