### PR TITLE
Fix: Doc prop name for `connect` property

### DIFF
--- a/docs/src/routes/docs/[...3]modules/core.md
+++ b/docs/src/routes/docs/[...3]modules/core.md
@@ -169,7 +169,7 @@ type RecommendedInjectedWallets = {
 
 ---
 
-#### **connectModal**
+#### **connect**
 
 An object that allows for customizing the connect modal layout and behavior
 


### PR DESCRIPTION
### Description
Docs update `connectModal` -> `connect` to match property name
