### PR TITLE
[core, react, vue]: Feature - Connect all previously connected wallets

### DIFF
--- a/docs/src/routes/docs/[...1]overview/[...1]introduction.md
+++ b/docs/src/routes/docs/[...1]overview/[...1]introduction.md
@@ -35,7 +35,9 @@ Web3-Onboard is the quickest and easiest way to add multi-wallet and multi-chain
 
 web3-onboard supports all EVM networks. Supporting a new network is simply a matter of adding its details in the Chains section upon initialization. For more information see [initialization options](https://onboard.blocknative.com/docs/modules/core#options).
 
+- Ethereum 
 - Arbitrum
+- Optimism
 - Avalanche
 - BNB Chain
 - Celo
@@ -44,8 +46,10 @@ web3-onboard supports all EVM networks. Supporting a new network is simply a mat
 - Gnosis Chain
 - Harmony One
 - Moonriver
-- Optimism
 - Polygon
+- Goerli
+- Sepolia
+- Core Goerli
 - Any other EVM network
 
 ### [Optional] Use an API key to fetch real time transaction data, balances & gas

--- a/docs/src/routes/docs/[...3]modules/core.md
+++ b/docs/src/routes/docs/[...3]modules/core.md
@@ -28,6 +28,7 @@ npm install @web3-onboard/core
 </Tabs>
 
 #### All Wallet Modules
+
 If you would like to support all wallets, then you can install all of the wallet modules:
 
 <Tabs values={['yarn', 'npm']}>
@@ -96,12 +97,13 @@ type InitOptions {
 }
 
 ```
+
 ---
 
 #### wallets
 
-An array of wallet modules that you would like to be presented to the user to select from when connecting a wallet. A wallet module is an abstraction that allows for easy interaction without needing to know the specifics of how that wallet works and are separate packages that can be included. 
-These modules are separate @web3-onboard packages such as `@web3-onboard/injected-wallets` or `@web3-onboard/ledger`. 
+An array of wallet modules that you would like to be presented to the user to select from when connecting a wallet. A wallet module is an abstraction that allows for easy interaction without needing to know the specifics of how that wallet works and are separate packages that can be included.
+These modules are separate @web3-onboard packages such as `@web3-onboard/injected-wallets` or `@web3-onboard/ledger`.
 For a full list click [here](#all-wallet-modules).
 
 ---
@@ -113,11 +115,11 @@ An array of Chains that your app supports:
 ```ts
 type Chain = {
   id: ChainId // hex encoded string, eg '0x1' for Ethereum Mainnet
-  namespace?: 'evm' // string indicating chain namespace. Defaults to 'evm' but will allow other chain namespaces in the future 
-  // PLEASE NOTE: Some wallets require an rpcUrl, label, and token for actions such as adding a new chain. 
-  // It is recommended to include rpcUrl, label, and token for full functionality. 
-  rpcUrl?: string // Recommended to include. Used for network requests. 
-  label?: string // Recommended to include. Used for display, eg Ethereum Mainnet. 
+  namespace?: 'evm' // string indicating chain namespace. Defaults to 'evm' but will allow other chain namespaces in the future
+  // PLEASE NOTE: Some wallets require an rpcUrl, label, and token for actions such as adding a new chain.
+  // It is recommended to include rpcUrl, label, and token for full functionality.
+  rpcUrl?: string // Recommended to include. Used for network requests.
+  label?: string // Recommended to include. Used for display, eg Ethereum Mainnet.
   token?: TokenSymbol // Recommended to include. The native token symbol, eg ETH, BNB, MATIC.
   color?: string // the color used to represent the chain and will be used as a background for the icon
   icon?: string // the icon to represent the chain
@@ -181,6 +183,9 @@ An object that allows for customizing the connect modal layout and behavior
 
 ```typescript copy
 type ConnectModalOptions = {
+  /**
+   * Display the connect modal sidebar - only applies to desktop views
+   */
   showSidebar?: boolean
   /**
    * Disabled close of the connect modal with background click and
@@ -188,11 +193,18 @@ type ConnectModalOptions = {
    * Defaults to false
    */
   disableClose?: boolean
-  /**If set to true, the last connected wallet will store in local storage.
-   * Then on init, onboard will try to reconnect to that wallet with
-   * no modals displayed
+  /**
+   * If set to true, the most recently connected wallet will store in
+   * local storage. Then on init, onboard will try to reconnect to
+   * that wallet with no modals displayed
    */
-  autoConnectLastWallet?: boolean // defaults to false
+  autoConnectLastWallet?: boolean
+  /**
+   * If set to true, all previously connected wallets will store in
+   * local storage. Then on init, onboard will try to reconnect to
+   * each wallet with no modals displayed
+   */
+  autoConnectAllPreviousWallet?: boolean
   /**
    * Customize the link for the `I don't have a wallet` flow shown on the
    * select wallet modal.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -82,11 +82,11 @@ An array of Chains that your app supports:
 type Chain = {
   id: ChainId // hex encoded string, eg '0x1' for Ethereum Mainnet
   namespace?: 'evm' // string indicating chain namespace. Defaults to 'evm' but will allow other chain namespaces in the future
-  // PLEASE NOTE: Some wallets require an rpcUrl, label, and token for actions such as adding a new chain. 
-  // It is recommended to include rpcUrl, label, and token for full functionality. 
+  // PLEASE NOTE: Some wallets require an rpcUrl, label, and token for actions such as adding a new chain.
+  // It is recommended to include rpcUrl, label, and token for full functionality.
   rpcUrl?: string // Recommended to include. Used for network requests (eg Alchemy or Infura end point).
-  label?: string // Recommended to include. Used for display, eg Ethereum Mainnet.  
-  token?: TokenSymbol // Recommended to include. The native token symbol, eg ETH, BNB, MATIC. 
+  label?: string // Recommended to include. Used for display, eg Ethereum Mainnet.
+  token?: TokenSymbol // Recommended to include. The native token symbol, eg ETH, BNB, MATIC.
   color?: string // the color used to represent the chain and will be used as a background for the icon
   icon?: string // the icon to represent the chain
   publicRpcUrl?: string // an optional public RPC used when adding a new chain config to the wallet
@@ -130,17 +130,28 @@ An object that allows for customization of the Connect Modal and accepts the typ
 
 ```typescript
 type ConnectModalOptions = {
+  /**
+   * Display the connect modal sidebar - only applies to desktop views
+   */
   showSidebar?: boolean
   /**
    * Disabled close of the connect modal with background click and
    * hides the close button forcing an action from the connect modal
+   * Defaults to false
    */
-  disableClose?: boolean // defaults to false
-  /**If set to true, the last connected wallet will store in local storage.
-   * Then on init, onboard will try to reconnect to that wallet with
-   * no modals displayed
+  disableClose?: boolean
+  /**
+   * If set to true, the most recently connected wallet will store in
+   * local storage. Then on init, onboard will try to reconnect to
+   * that wallet with no modals displayed
    */
-  autoConnectLastWallet?: boolean // defaults to false
+  autoConnectLastWallet?: boolean
+  /**
+   * If set to true, all previously connected wallets will store in
+   * local storage. Then on init, onboard will try to reconnect to
+   * each wallet with no modals displayed
+   */
+  autoConnectAllPreviousWallet?: boolean
   /**
    * Customize the link for the `I don't have a wallet` flow shown on the
    * select wallet modal.
@@ -1345,7 +1356,6 @@ export default config
 
 Checkout a boilerplate example (here)[https://github.com/blocknative/web3-onboard/tree/develop/examples/with-sveltekit]
 
-
 Add the following dev dependencies:
 
 `yarn add rollup-plugin-polyfill-node -D`
@@ -1442,19 +1452,22 @@ export default config
 
 If an error presents around `window` being undefined remove the `define.global` block.
 Add this to your `app.html`
+
 ```html
 <script>
-      var global = global || window
+  var global = global || window
 </script>
 ```
 
 ##### Buffer polyfill
+
 It seems some component or dependency requires Node's Buffer. To polyfill this, the simplest way I could find was to install the buffer package and include the following in web3-onboard.ts:
 
 ```javascript
 import { Buffer } from 'buffer'
 globalThis.Buffer = Buffer
 ```
+
 See [this github issue](https://github.com/blocknative/web3-onboard/issues/1568#issuecomment-1463963462) for further troubleshooting
 
 ### Vite
@@ -1546,7 +1559,6 @@ Checkout a boilerplate example for NextJS v13 (here)[https://github.com/blocknat
 
 Checkout a boilerplate example for NextJS (here)[https://github.com/blocknative/web3-onboard/tree/develop/examples/with-nextjs]
 
-
 ## Package Managers
 
 ### npm and yarn
@@ -1554,5 +1566,6 @@ Checkout a boilerplate example for NextJS (here)[https://github.com/blocknative/
 Web3-Onboard will work out of the box with `npm` and `yarn` support.
 
 ### pnpm
+
 We have had issues reported when using `pnpm` as the package manager when working with web3-onboard.
 As we work to understand this new manager more and the issues around it we recommend using `npm` or `yarn` for now.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.15.6-alpha.4",
+  "version": "2.15.6-alpha.5",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.15.6-alpha.3",
+  "version": "2.15.6-alpha.4",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/disconnect.ts
+++ b/packages/core/src/disconnect.ts
@@ -4,7 +4,7 @@ import { removeWallet } from './store/actions.js'
 import { disconnectWallet$ } from './streams.js'
 import type { DisconnectOptions, WalletState } from './types.js'
 import { validateDisconnectOptions } from './validation.js'
-import { delLocalStore, getLocalStore } from './utils'
+import { delLocalStore, getLocalStore, setLocalStore } from './utils'
 import { STORAGE_KEYS } from './constants'
 
 async function disconnect(options: DisconnectOptions): Promise<WalletState[]> {
@@ -35,7 +35,15 @@ async function disconnect(options: DisconnectOptions): Promise<WalletState[]> {
   disconnectWallet$.next(label)
   removeWallet(label)
 
-  if (getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET) === label) {
+  const labels = JSON.parse(getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET))
+
+  if (Array.isArray(labels) && labels.indexOf(label) >= 0) {
+    setLocalStore(
+      STORAGE_KEYS.LAST_CONNECTED_WALLET,
+      JSON.stringify(labels.filter(walletLabel => walletLabel !== label))
+    )
+  }
+  if (typeof labels === 'string' && labels === label) {
     delLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -231,22 +231,28 @@ function init(options: InitOptions): OnboardAPI {
     connect &&
     (connect.autoConnectLastWallet || connect.autoConnectAllPreviousWallet)
   ) {
-    const lastConnectedWallets = JSON.parse(
-      getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
+    const lastConnectedWallets = getLocalStore(
+      STORAGE_KEYS.LAST_CONNECTED_WALLET
     )
-
-    // Handle for legacy single wallet approach
-    if (lastConnectedWallets && typeof lastConnectedWallets === 'string') {
-      API.connectWallet({
-        autoSelect: { label: lastConnectedWallets, disableModals: true }
-      })
-    }
-    if (
-      lastConnectedWallets &&
-      Array.isArray(lastConnectedWallets) &&
-      lastConnectedWallets.length
-    ) {
-      connectAllPreviousWallets(lastConnectedWallets, connect)
+    try {
+      const lastConnectedWalletsParsed = JSON.parse(lastConnectedWallets)
+      if (
+        lastConnectedWalletsParsed &&
+        Array.isArray(lastConnectedWalletsParsed) &&
+        lastConnectedWalletsParsed.length
+      ) {
+        connectAllPreviousWallets(lastConnectedWalletsParsed, connect)
+      }
+    } catch (err) {
+      // Handle for legacy single wallet approach
+      if (lastConnectedWallets && typeof lastConnectedWallets === 'string') {
+        API.connectWallet({
+          autoSelect: {
+            label: lastConnectedWallets,
+            disableModals: true
+          }
+        })
+      }
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -245,7 +245,8 @@ function init(options: InitOptions): OnboardAPI {
       }
     } catch (err) {
       // Handle for legacy single wallet approach
-      if (lastConnectedWallets && typeof lastConnectedWallets === 'string') {
+      // Above try will throw syntax error is local storage is not json
+      if (err instanceof SyntaxError && lastConnectedWallets) {
         API.connectWallet({
           autoSelect: {
             label: lastConnectedWallets,
@@ -277,7 +278,6 @@ const connectAllPreviousWallets = async (
       const walletConnectionPromise = await API.connectWallet({
         autoSelect: { label: parsedWalletList[i], disableModals: true }
       })
-
       // Update localStorage list for available wallets
       if (walletConnectionPromise.some(r => r.label === parsedWalletList[i])) {
         activeWalletsList.unshift(parsedWalletList[i])

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,7 +241,11 @@ function init(options: InitOptions): OnboardAPI {
         autoSelect: { label: lastConnectedWallets, disableModals: true }
       })
     }
-    if (lastConnectedWallets && Array.isArray(lastConnectedWallets)) {
+    if (
+      lastConnectedWallets &&
+      Array.isArray(lastConnectedWallets) &&
+      lastConnectedWallets.length
+    ) {
       connectAllPreviousWallets(lastConnectedWallets, connect)
     }
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -184,11 +184,16 @@ export type ConnectModalOptions = {
    * Defaults to false
    */
   disableClose?: boolean
-  /**If set to true, the last connected wallet will store in local storage.
-   * Then on init, onboard will try to reconnect to that wallet with
-   * no modals displayed
+  /**If set to true, the most recently connected wallet will store in 
+   * local storage. Then on init, onboard will try to reconnect to 
+   * that wallet with no modals displayed
    */
   autoConnectLastWallet?: boolean
+  /**If set to true, all previously connected wallets will store in 
+   * local storage. Then on init, onboard will try to reconnect to 
+   * each wallet with no modals displayed
+   */
+  autoConnectAllPreviousWallet?: boolean
   /**
    * Customize the link for the `I don't have a wallet` flow shown on the
    * select wallet modal.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -184,12 +184,14 @@ export type ConnectModalOptions = {
    * Defaults to false
    */
   disableClose?: boolean
-  /**If set to true, the most recently connected wallet will store in 
+  /** 
+   * If set to true, the most recently connected wallet will store in 
    * local storage. Then on init, onboard will try to reconnect to 
    * that wallet with no modals displayed
    */
   autoConnectLastWallet?: boolean
-  /**If set to true, all previously connected wallets will store in 
+  /** 
+   * If set to true, all previously connected wallets will store in 
    * local storage. Then on init, onboard will try to reconnect to 
    * each wallet with no modals displayed
    */

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -174,6 +174,7 @@ const connectModalOptions = Joi.object({
   showSidebar: Joi.boolean(),
   disableClose: Joi.boolean(),
   autoConnectLastWallet: Joi.boolean(),
+  autoConnectAllPreviousWallet: Joi.boolean(),
   iDontHaveAWalletLink: Joi.string(),
   disableUDResolution: Joi.boolean()
 })

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -216,18 +216,22 @@
         state.get().connect.autoConnectLastWallet ||
         state.get().connect.autoConnectAllPreviousWallet
       ) {
-        let labelsList: string | Array<String> = JSON.parse(
-          getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
-        )
+        let labelsList: string | Array<String>
+        getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
 
-        if (labelsList && Array.isArray(labelsList)) {
-          const tempLabels = labelsList
-          labelsList = [...new Set([label, ...tempLabels])]
-        }
-
-        if (labelsList && typeof labelsList === 'string') {
-          const tempLabel = labelsList
-          labelsList = [tempLabel]
+        try {
+          let labelsListParsed: Array<String> = JSON.parse(
+            getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
+          )
+          if (labelsList && Array.isArray(labelsList)) {
+            const tempLabels = labelsListParsed
+            labelsList = [...new Set([label, ...tempLabels])]
+          }
+        } catch (err) {
+          if (labelsList && typeof labelsList === 'string') {
+            const tempLabel = labelsList
+            labelsList = [tempLabel]
+          }
         }
 
         if (!labelsList) labelsList = [label]

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -216,26 +216,30 @@
         state.get().connect.autoConnectLastWallet ||
         state.get().connect.autoConnectAllPreviousWallet
       ) {
-        let labelsList: string | Array<String>
-        getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
+        let labelsList: string | Array<String> = getLocalStore(
+          STORAGE_KEYS.LAST_CONNECTED_WALLET
+        )
 
         try {
-          let labelsListParsed: Array<String> = JSON.parse(
-            getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
-          )
-          if (labelsList && Array.isArray(labelsList)) {
+          let labelsListParsed: Array<String> = JSON.parse(labelsList)
+          if (labelsListParsed && Array.isArray(labelsListParsed)) {
             const tempLabels = labelsListParsed
             labelsList = [...new Set([label, ...tempLabels])]
           }
         } catch (err) {
-          if (labelsList && typeof labelsList === 'string') {
+          if (
+            err instanceof SyntaxError &&
+            labelsList &&
+            typeof labelsList === 'string'
+          ) {
             const tempLabel = labelsList
             labelsList = [tempLabel]
+          } else {
+            throw new Error(err as string)
           }
         }
 
         if (!labelsList) labelsList = [label]
-
         setLocalStore(
           STORAGE_KEYS.LAST_CONNECTED_WALLET,
           JSON.stringify(labelsList)

--- a/packages/core/src/views/connect/Index.svelte
+++ b/packages/core/src/views/connect/Index.svelte
@@ -8,7 +8,12 @@
   import { state } from '../../store/index.js'
   import { connectWallet$, onDestroy$ } from '../../streams.js'
   import { addWallet, updateAccount } from '../../store/actions.js'
-  import { validEnsChain, isSVG, setLocalStore } from '../../utils.js'
+  import {
+    validEnsChain,
+    isSVG,
+    setLocalStore,
+    getLocalStore
+  } from '../../utils.js'
   import CloseButton from '../shared/CloseButton.svelte'
   import Modal from '../shared/Modal.svelte'
   import Agreement from './Agreement.svelte'
@@ -207,8 +212,30 @@
       }
 
       // store last connected wallet
-      if (state.get().connect.autoConnectLastWallet) {
-        setLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET, label)
+      if (
+        state.get().connect.autoConnectLastWallet ||
+        state.get().connect.autoConnectAllPreviousWallet
+      ) {
+        let labelsList: string | Array<String> = JSON.parse(
+          getLocalStore(STORAGE_KEYS.LAST_CONNECTED_WALLET)
+        )
+
+        if (labelsList && Array.isArray(labelsList)) {
+          const tempLabels = labelsList
+          labelsList = [...new Set([label, ...tempLabels])]
+        }
+
+        if (labelsList && typeof labelsList === 'string') {
+          const tempLabel = labelsList
+          labelsList = [tempLabel]
+        }
+
+        if (!labelsList) labelsList = [label]
+
+        setLocalStore(
+          STORAGE_KEYS.LAST_CONNECTED_WALLET,
+          JSON.stringify(labelsList)
+        )
       }
 
       const chain = await getChainId(provider)

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
     "webpack-dev-server": "4.7.4"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.15.6-alpha.3",
+    "@web3-onboard/core": "^2.15.6-alpha.4",
     "@web3-onboard/coinbase": "^2.2.1-alpha.1",
     "@web3-onboard/transaction-preview": "^2.0.5-alpha.1",
     "@web3-onboard/dcent": "^2.2.4-alpha.1",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -23,7 +23,7 @@
     "webpack-dev-server": "4.7.4"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.15.6-alpha.4",
+    "@web3-onboard/core": "^2.15.6-alpha.5",
     "@web3-onboard/coinbase": "^2.2.1-alpha.1",
     "@web3-onboard/transaction-preview": "^2.0.5-alpha.1",
     "@web3-onboard/dcent": "^2.2.4-alpha.1",

--- a/packages/demo/src/App.svelte
+++ b/packages/demo/src/App.svelte
@@ -252,7 +252,8 @@
     connect: {
       // disableClose: true,
       // disableUDResolution: true,
-      autoConnectLastWallet: true
+      autoConnectLastWallet: true,
+      autoConnectAllPreviousWallet: true
     },
     appMetadata: {
       name: 'Blocknative',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.6.7-alpha.4",
+  "version": "2.6.7-alpha.5",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,7 +62,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@web3-onboard/core": "^2.15.6-alpha.4",
+    "@web3-onboard/core": "^2.15.6-alpha.5",
     "@web3-onboard/common": "^2.2.4-alpha.1",
     "use-sync-external-store": "1.0.0"
   },

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.5.7-alpha.4",
+  "version": "2.5.7-alpha.5",
   "description": "A collection of Vue Composables for integrating Web3-Onboard in to a Vue or Nuxt project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -63,7 +63,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.2.4-alpha.1",
-    "@web3-onboard/core": "^2.15.6-alpha.4",
+    "@web3-onboard/core": "^2.15.6-alpha.5",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
Adds option to reconnect all previously connected wallets as an option.

Wallets will be reconnected in the order they were previously held within the array.

A new format is introduced within the PR for local storage saving of the wallet labels with an array of strings being used instead of a string. This will be the case regardless if the dev elects usage of `autoConnectAllPreviousWallet` or `autoConnectLastWallet`

```ts
type ConnectModalOptions = {
  ...
  /** 
   * If set to true, all previously connected wallets will store in 
   * local storage. Then on init, onboard will try to reconnect to 
   * each wallet with no modals displayed
   */
  autoConnectAllPreviousWallet?: boolean
}
```

### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [x] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation
