### PR TITLE
update favicon on docs site

### DIFF
--- a/docs/src/app.html
+++ b/docs/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/x-icon" href="https://www.blocknative.com/hubfs/Icons%20and%20Illustrations/blocknative%20favicon.png" />
+    <link rel="icon" type="image/x-icon" href="/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
 

--- a/docs/src/app.html
+++ b/docs/src/app.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/x-icon" href="%sveltekit.assets%/favicon.png" />
+    <link rel="icon" type="image/x-icon" href="https://www.blocknative.com/hubfs/Icons%20and%20Illustrations/blocknative%20favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
 


### PR DESCRIPTION
### Description
Update favicon on docs site

<img width="1272" alt="Screenshot 2023-03-28 at 12 04 33 PM" src="https://user-images.githubusercontent.com/33187102/228329053-758839a8-7de5-4924-a885-4fea3ffcf45f.png">
