### PR TITLE
Fix: getServerSnapshot call

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.8.0-alpha.1",
+  "version": "2.8.0-alpha.2",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/react/src/hooks/useAppState.ts
+++ b/packages/react/src/hooks/useAppState.ts
@@ -28,6 +28,6 @@ export const useAppState: {
     return stateKey ? snapshot[stateKey] : snapshot
   }, [stateKey])
 
-  const getServerSnapshot = () => get() || getSnapshot
+  const getServerSnapshot = () => getSnapshot()
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }


### PR DESCRIPTION
### Description
Fixes useWallets call mentioned in issue https://github.com/blocknative/web3-onboard/issues/1630

(Please ignore the typerror- it was coming from my frontier wallet extension)

Was this- returning whole state object: 
<img width="1403" alt="Screenshot 2023-04-20 at 12 54 25 PM" src="https://user-images.githubusercontent.com/33187102/233461084-b816ba5c-8583-4fd0-a698-862c5f66fa46.png">

Now returns array (not state object):

<img width="1403" alt="Screenshot 2023-04-20 at 12 22 27 PM" src="https://user-images.githubusercontent.com/33187102/233454269-d3c972b4-c900-49c9-8e91-cbc8bc06e5f3.png">

<img width="1403" alt="Screenshot 2023-04-20 at 12 22 45 PM" src="https://user-images.githubusercontent.com/33187102/233454330-d6145b18-61c0-429c-ba97-accb9e0f8d09.png">

#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [x] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation

