### PR TITLE
Fix: Add Dependency to Vanilla-JS example

### DIFF
--- a/examples/with-vanilla-js/package.json
+++ b/examples/with-vanilla-js/package.json
@@ -13,7 +13,8 @@
     "css-loader": "^6.7.3",
     "style-loader": "^3.3.2",
     "webpack": "^5.79.0",
-    "webpack-cli": "^5.0.1"
+    "webpack-cli": "^5.0.2",
+    "webpack-dev-server": "^4.13.3"
   },
   "dependencies": {
     "@web3-onboard/coinbase": "^2.2.2",


### PR DESCRIPTION
### Description
Adds webpack-dev-server as dev dependency to vanilla-js example

To confirm- 
cd examples/with-vanilla-js
npm i && npm run dev
dev server should start and you should be able to connect a wallet


#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [ ] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [ ] Check the box that allows repo maintainers to update this PR
- [ ] Test locally to make sure this feature/fix works
- [ ] Run `yarn check-all` to confirm there are not any associated errors
- [ ] Confirm this PR passes Circle CI checks
- [ ] Add or update relevant information in the documentation
