### PR TITLE
Fix: Make chainIdHex/id case insensitive in setChain

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.18.0-alpha.1",
+  "version": "2.18.0-alpha.2",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/chain.ts
+++ b/packages/core/src/chain.ts
@@ -36,7 +36,7 @@ async function setChain(options: {
 
   // validate that chainId has been added to chains
   const chain = chains.find(
-    ({ namespace, id }) => namespace === chainNamespace && id === chainIdHex
+    ({ namespace, id }) => namespace === chainNamespace && id.toLowerCase() === chainIdHex.toLowerCase()
   )
 
   if (!chain) {


### PR DESCRIPTION
### Description
This fixes a minor problem probably introduced in https://github.com/blocknative/web3-onboard/pull/1062

Since we're making the hexId lowercase in the init action - we should do the same for the `setChain` action. Right now I'm trying to implement Optimism Goerli which is using `0x1A4` as an ID. This is getting converted to `0x1a4` internally and then compared to the response of eth_chainId which is in my case, sadly, `0x1A4` (and I can't change that).


#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [x] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation

### Docs Checklist
- [x] Include a screenshot of any changes ([see docs README on running locally](https://github.com/blocknative/web3-onboard/blob/develop/docs/README.md))
- [x] Add/update the appropriate package README (if applicable)
- [x] Add/update the related module in the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) (if applicable)
- [x] Add/update the related package in the `docs/package.json` file (if applicable)

### If this PR includes changes to add an injected wallet or SDK wallet module: 
Please complete the following using the internal demo package.
To run this demo use the command `yarn && yarn dev` to get the project running at `http://localhost:8080/`

#### Tests with demo app (injected)
- [x] send transaction
- [x] switch chains
- [x] sign message
- [x] sign typed message
- [x] disconnect

#### Tests with demo app (SDK)
- [x] send transaction
- [x] switch chains
- [x] sign message
- [x] sign typed message
- [x] disconnect