### PR TITLE
Fix: web3auth publish flow for latest deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ aliases:
   - &create-npm-config
     run:
       name: Create NPM rc file
-      command: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > .npmrc
+      command: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > ~/.npmrc
 
   - &publish-npm
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,8 +99,8 @@ aliases:
     run:
       name: Publish package to NPM
       command: |
-      npm config set //registry.npmjs.org/:_authToken=${npm_TOKEN}
-      npm publish --access public
+        npm config set //registry.npmjs.org/:_authToken=${npm_TOKEN}
+        npm publish --access public
 
   - &publish-npm-tag-as-next
     run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,9 @@ aliases:
   - &publish-npm
     run:
       name: Publish package to NPM
-      command: npm publish --access public
+      command: |
+      npm config set //registry.npmjs.org/:_authToken=${npm_TOKEN}
+      npm publish --access public
 
   - &publish-npm-tag-as-next
     run:
@@ -287,7 +289,7 @@ jobs:
       - node-build-steps
   build-web3auth:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:16.18.1
     working_directory: ~/web3-onboard-monorepo/packages/web3auth
     steps:
       - node-build-steps
@@ -511,7 +513,7 @@ jobs:
       - node-staging-build-steps
   build-staging-web3auth:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:16.18.1
     working_directory: ~/web3-onboard-monorepo/packages/web3auth
     steps:
       - node-staging-build-steps

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.8.2-alpha.4",
+  "version": "2.8.2-alpha.5",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/web3auth/package.json
+++ b/packages/web3auth/package.json
@@ -58,9 +58,9 @@
   },
   "dependencies": {
     "@web3-onboard/common": "^2.3.2-alpha.2",
-    "@solana/web3.js": "1.73.0",
-    "@web3auth/base": "5.0.1",
-    "@web3auth/modal": "5.0.1",
+    "@solana/web3.js": "^1.73.0",
+    "@web3auth/base": "^5.0.1",
+    "@web3auth/modal": "^5.0.1",
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
web3auth requires a node version of 16.18.1 but when adjusting only the node version within the docker container the .npmrc file is ignored. 
These updates should ensure the .npmrc is not ignored 🤞🏼 