### PR TITLE
Adding Rabby's open-sourced relay service after WalletConnect v1.0 relay servers' shutdown

### DIFF
--- a/docs/src/routes/docs/[...4]wallets/[...22]uauth/+page.md
+++ b/docs/src/routes/docs/[...4]wallets/[...22]uauth/+page.md
@@ -36,7 +36,7 @@ type UauthInitOptions = {
   redirectUri: string // required and will throw an error if not included: used for pop-up and callback redirection
   scope?: string // default = 'openid wallet'
   shouldLoginWithRedirect?: boolean // if true, redirects to your callback page
-  bridge?: string // default = 'https://bridge.walletconnect.org'
+  bridge?: string // default = 'https://derelay.rabby.io'
   qrcodeModalOptions?: {
     mobileLinks: string[] // set the order and list of mobile linking wallets
   }

--- a/docs/src/routes/docs/[...4]wallets/[...24]walletconnect/+page.md
+++ b/docs/src/routes/docs/[...4]wallets/[...24]walletconnect/+page.md
@@ -33,7 +33,7 @@ npm install @web3-onboard/walletconnect
 
 ```typescript
 type WalletConnectOptions = {
-  bridge?: string // default = 'https://bridge.walletconnect.org'
+  bridge?: string // default = 'https://derelay.rabby.io'
   qrcodeModalOptions?: {
     mobileLinks: string[] // set the order and list of mobile linking wallets
   }

--- a/packages/uauth/README.md
+++ b/packages/uauth/README.md
@@ -12,7 +12,7 @@
 
 ## Options
 
-Follow the [Login Client Congifuration Docs](https://docs.unstoppabledomains.com/login-with-unstoppable/login-integration-guides/login-client-configuration/) on the Unstoppable Domains website to get setup with your clientID and redirectUri. 
+Follow the [Login Client Congifuration Docs](https://docs.unstoppabledomains.com/login-with-unstoppable/login-integration-guides/login-client-configuration/) on the Unstoppable Domains website to get setup with your clientID and redirectUri.
 **Note:** The Redirection URI value(s) in the client configuration MUST exactly match the redirect_uri parameter value used in `UauthInitOptions`. More specifics can be found in the [Rules for Redirect URIs Docs](https://docs.unstoppabledomains.com/login-with-unstoppable/login-integration-guides/login-client-configuration/#rules-for-redirect-uris).
 
 ```typescript
@@ -21,7 +21,7 @@ type UauthInitOptions = {
   redirectUri: string // required and will throw an error if not included: used for pop-up and callback redirection
   scope?: string // default = 'openid wallet'
   shouldLoginWithRedirect?: boolean // if true, redirects to your callback page
-  bridge?: string // default = 'https://bridge.walletconnect.org'
+  bridge?: string // default = 'https://derelay.rabby.io'
   qrcodeModalOptions?: {
     mobileLinks: string[] // set the order and list of mobile linking wallets
   }
@@ -69,7 +69,7 @@ console.log(connectedWallets)
 ### Accessing the UAuth configuration
 
 When Unstoppable Domains is connected the UAuth user instance is exposed.
-This can be used to get information related to the user scopes requested through the `UauthInitOptions`. 
+This can be used to get information related to the user scopes requested through the `UauthInitOptions`.
 
 ```typescript
 const wallets$ = onboard.state.select('wallets').pipe(share())

--- a/packages/uauth/src/index.ts
+++ b/packages/uauth/src/index.ts
@@ -34,7 +34,7 @@ function uauth(options: UauthInitOptions): WalletInit {
       redirectUri,
       scope = 'openid wallet',
       shouldLoginWithRedirect,
-      bridge = 'https://bridge.walletconnect.org',
+      bridge = 'https://derelay.rabby.io',
       qrcodeModalOptions,
       connectFirstChainId
     } = options || {}

--- a/packages/uauth/src/types.ts
+++ b/packages/uauth/src/types.ts
@@ -16,7 +16,7 @@ export type UauthInitOptions = {
    */
   shouldLoginWithRedirect?: boolean
   /**
-   * Optional url string: default = 'https://bridge.walletconnect.org'
+   * Optional url string: default = 'https://derelay.rabby.io'
    */
   bridge?: string
   qrcodeModalOptions?: {

--- a/packages/walletconnect/README.md
+++ b/packages/walletconnect/README.md
@@ -14,7 +14,7 @@ _For an up to date list please see the [WalletConnect Explorer](https://explorer
 
 ```typescript
 type WalletConnectOptions = {
-  bridge?: string // default = 'https://bridge.walletconnect.org'
+  bridge?: string // default = 'https://derelay.rabby.io'
   qrcodeModalOptions?: {
     mobileLinks: string[] // set the order and list of mobile linking wallets
   }

--- a/packages/walletconnect/src/v1.ts
+++ b/packages/walletconnect/src/v1.ts
@@ -13,7 +13,7 @@ function walletConnect(
   options: WalletConnectOptions = { version: 1 }
 ): WalletInit {
   const {
-    bridge = 'https://bridge.walletconnect.org',
+    bridge = 'https://derelay.rabby.io',
     qrcodeModalOptions,
     connectFirstChainId,
     handleUri


### PR DESCRIPTION
### Description
<!-- Add a description of the fix or feature here -->

#### Issue

WalletConnect v1.0 relay server is expected to be offline on 28 June, 2023. To ensure uninterrupted usage and connectivity following the official v1.0 server shutdown, we are proposing the integration of [Rabby](https://github.com/RabbyHub/)'s open-sourced relay service. This relay service, maintained by Rabby, will guarantee continued connection between Dapps and Wallets using WalletConnect for users.

#### Solution

We have included Rabby's self-host relay(https://derelay.rabby.io/) address in the web3 Wallet Connect kit, ensuring that users can connect to Dapp using WalletConnect. This address will become effective once the official relay server shuts down.

#### Testing plan

We have thoroughly tested the solution in both the testing environment and the live online environment. Based on our testing, we are confident that the solution will enable users to connect to Dapps using WalletConnect without any issues.


#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [x] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation

### Docs Checklist
- [x] Include a screenshot of any changes ([see docs README on running locally](https://github.com/blocknative/web3-onboard/blob/develop/docs/README.md))
- [x] Add/update the appropriate package README (if applicable)
- [x] Add/update the related module in the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) (if applicable)
- [x] Add/update the related package in the `docs/package.json` file (if applicable)

### If this PR includes changes to add an injected wallet or SDK wallet module: 
Please complete the following using the internal demo package.
To run this demo use the command `yarn && yarn dev` to get the project running at `http://localhost:8080/`

#### Tests with demo app (injected)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect

#### Tests with demo app (SDK)
- [x] send transaction
- [x] switch chains
- [x] sign message
- [x] sign typed message
- [x] disconnect