### PR TITLE
fix: arrayify `accountsChanged` payload

### DIFF
--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletconnect",
-  "version": "2.3.9",
+  "version": "2.3.10-alpha",
   "description": "WalletConnect SDK module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -62,7 +62,7 @@
     "@ethersproject/providers": "5.5.0",
     "@walletconnect/client": "^1.8.0",
     "@walletconnect/ethereum-provider": "2.8.0",
-    "@walletconnect/modal":"2.4.3",
+    "@walletconnect/modal": "2.4.3",
     "@walletconnect/qrcode-modal": "^1.8.0",
     "@web3-onboard/common": "^2.3.3",
     "rxjs": "^7.5.2"

--- a/packages/walletconnect/src/v2.ts
+++ b/packages/walletconnect/src/v2.ts
@@ -121,7 +121,8 @@ function walletConnect(options?: WalletConnectOptions): WalletInit {
             fromEvent(this.connector, 'accountsChanged', payload => payload)
               .pipe(takeUntil(this.disconnected$))
               .subscribe({
-                next: accounts => {
+                next: payload => {
+                  const accounts = Array.isArray(payload) ? payload : [payload]
                   this.emit('accountsChanged', accounts)
                 },
                 error: console.warn

--- a/yarn.lock
+++ b/yarn.lock
@@ -3984,6 +3984,19 @@
     "@walletconnect/window-getters" "^1.0.1"
     tslib "1.14.1"
 
+"@web3-onboard/walletconnect@^2.3.9":
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@web3-onboard/walletconnect/-/walletconnect-2.3.9.tgz#a569db39db61c927fee70744c5fcf015dad47042"
+  integrity sha512-0n1UesJLNNU33j/I0X4QHVL8AhFb6Oyo/ZU3EEYeDBev2Cis1A6Bvl38BfmeBBMdBOZBxeTOC2kNeRjvvvpzhA==
+  dependencies:
+    "@ethersproject/providers" "5.5.0"
+    "@walletconnect/client" "^1.8.0"
+    "@walletconnect/ethereum-provider" "2.8.0"
+    "@walletconnect/modal" "2.4.3"
+    "@walletconnect/qrcode-modal" "^1.8.0"
+    "@web3-onboard/common" "^2.3.3"
+    rxjs "^7.5.2"
+
 "@web3-react/abstract-connector@^6.0.7":
   version "6.0.7"
   resolved "https://registry.yarnpkg.com/@web3-react/abstract-connector/-/abstract-connector-6.0.7.tgz#401b3c045f1e0fab04256311be49d5144e9badc6"


### PR DESCRIPTION
### Description

The `accountsChanged$` listener [destructures the first address](https://github.com/blocknative/web3-onboard/blob/develop/packages/core/src/provider.ts#L125) and the [`accountsChanged` payload of WalletConnect](https://github.com/blocknative/web3-onboard/blob/develop/packages/walletconnect/src/v2.ts#L121) is an array of addresses.

However, `fromEvent` [only returns the first element of an array](https://github.com/ReactiveX/rxjs/blob/7.x/src/internal/observable/fromEvent.ts#L295) if it has one element. This means, `accountsChanged$` saves `"0"` as a connected wallet because it destructures the first character of the address.

To fix this, the payload is "arrayified" so that `accountsChanged$` _always_ receives an array of addresses. I considered making this change to the `accountsChanged$` listener directly but we only encountered a problem with WalletConnect.

Note: [we've successfully implemented a patch](https://github.com/safe-global/safe-wallet-web/pull/2095/files#diff-6ca9e734e2d18519d25695469a32078ea929372e329465fab1ef7bf20fd6bd8e) for the above already.

#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [x] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation

### Docs Checklist
- [x] Include a screenshot of any changes ([see docs README on running locally](https://github.com/blocknative/web3-onboard/blob/develop/docs/README.md))
- [x] Add/update the appropriate package README (if applicable)
- [x] Add/update the related module in the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) (if applicable)
- [x] Add/update the related package in the `docs/package.json` file (if applicable)

### If this PR includes changes to add an injected wallet or SDK wallet module: 
Please complete the following using the internal demo package.
To run this demo use the command `yarn && yarn dev` to get the project running at `http://localhost:8080/`

#### Tests with demo app (injected)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect

#### Tests with demo app (SDK)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect