### PR TITLE
Update - Tx Boost URL to non-alpha, OKX wallet available on all devices

### DIFF
--- a/docs/src/routes/docs/[...3]modules/[...1]core/+page.md
+++ b/docs/src/routes/docs/[...3]modules/[...1]core/+page.md
@@ -156,7 +156,7 @@ type Chain = {
   namespace?: 'evm' // string indicating chain namespace. Defaults to 'evm' but will allow other chain namespaces in the future
   // PLEASE NOTE: Some wallets require an rpcUrl, label, and token for actions such as adding a new chain.
   // It is recommended to include rpcUrl, label, and token for full functionality.
-  rpcUrl?: string // Recommended to include. Used for network requests.
+  rpcUrl?: string // Recommended to include. Used for network requests (eg Alchemy or Infura end point).
   label?: string // Recommended to include. Used for display, eg Ethereum Mainnet.
   token?: TokenSymbol // Recommended to include. The native token symbol, eg ETH, BNB, MATIC.
   color?: string // the color used to represent the chain and will be used as a background for the icon
@@ -164,7 +164,7 @@ type Chain = {
   publicRpcUrl?: string // an optional public RPC used when adding a new chain config to the wallet
   blockExplorerUrl?: string // also used when adding a new config to the wallet
   secondaryTokens?: SecondaryTokens[] // An optional array of tokens (max of 5) to be available to the dapp in the app state object per wallet within the wallet account and displayed in Account Center (if enabled)
-  protectedRpcUrl?: string //An optional protected RPC URL - Defaults to Blocknative's private RPC aggregator to allow users to update the chain RPC within their wallet, specifically for private RPCs that protect user transactions. More information can be found at `https://docs.blocknative.com/blocknative-mev-protection/transaction-boost-alpha`
+  protectedRpcUrl?: string //An optional protected RPC URL - Defaults to Blocknative's private RPC aggregator to allow users to update the chain RPC within their wallet, specifically for private RPCs that protect user transactions. More information can be found at `https://docs.blocknative.com/blocknative-mev-protection/transaction-boost`
 }
 
 interface SecondaryTokens {

--- a/docs/src/routes/docs/[...4]wallets/[...11]injected/+page.md
+++ b/docs/src/routes/docs/[...4]wallets/[...11]injected/+page.md
@@ -299,7 +299,7 @@ const injected = injectedModule({
 - Trust - _Desktop & Mobile_
 - SafePal - _Desktop & Mobile_
 - Zerion - _Desktop & Mobile_
-- OKX Wallet - _Desktop_
+- OKX Wallet - _Desktop & Mobile_
 - Taho (Previously named Tally Ho wallet) - _Desktop_
 - Opera - _Desktop & Mobile_
 - Status - _Mobile_
@@ -345,6 +345,7 @@ const injected = injectedModule({
 - Ronin Wallet - _Desktop & Mobile_
 - Coin98 Wallet - _Desktop & Mobile_
 - SubWallet - _Desktop & Mobile_
+- Kayros - _Desktop_
 
 ## Build Environments
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -148,7 +148,7 @@ type Chain = {
   publicRpcUrl?: string // an optional public RPC used when adding a new chain config to the wallet
   blockExplorerUrl?: string // also used when adding a new config to the wallet
   secondaryTokens?: SecondaryTokens[] // An optional array of tokens (max of 5) to be available to the dapp in the app state object per wallet within the wallet account and displayed in Account Center (if enabled)
-  protectedRpcUrl?: string //An optional protected RPC URL - Defaults to Blocknative's private RPC aggregator to allow users to update the chain RPC within their wallet, specifically for private RPCs that protect user transactions. More information can be found at `https://docs.blocknative.com/blocknative-mev-protection/transaction-boost-alpha`
+  protectedRpcUrl?: string //An optional protected RPC URL - Defaults to Blocknative's private RPC aggregator to allow users to update the chain RPC within their wallet, specifically for private RPCs that protect user transactions. More information can be found at `https://docs.blocknative.com/blocknative-mev-protection/transaction-boost`
 }
 interface SecondaryTokens {
   /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.21.1-alpha.2",
+  "version": "2.21.1-alpha.3",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -38,4 +38,4 @@ export const STORAGE_KEYS = {
 export const MOBILE_WINDOW_WIDTH = 768
 
 export const BN_BOOST_RPC_URL = 'https://rpc.blocknative.com/boost'
-export const BN_BOOST_INFO_URL = 'https://docs.blocknative.com/blocknative-mev-protection/transaction-boost-alpha'
+export const BN_BOOST_INFO_URL = 'https://docs.blocknative.com/blocknative-mev-protection/transaction-boost'

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -31,7 +31,7 @@
     "@web3-onboard/blocto": "2.0.0",
     "@web3-onboard/cede-store": "^2.1.0",
     "@web3-onboard/coinbase": "^2.2.5",
-    "@web3-onboard/core": "^2.21.1-alpha.2",
+    "@web3-onboard/core": "^2.21.1-alpha.3",
     "@web3-onboard/dcent": "^2.2.7",
     "@web3-onboard/enkrypt": "^2.0.3",
     "@web3-onboard/fortmatic": "^2.0.18",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -40,7 +40,7 @@
     "@web3-onboard/gas": "^2.1.7",
     "@web3-onboard/gnosis": "^2.1.10",
     "@web3-onboard/infinity-wallet": "^2.0.3",
-    "@web3-onboard/injected-wallets": "^2.10.6-alpha.1",
+    "@web3-onboard/injected-wallets": "^2.10.6-alpha.2",
     "@web3-onboard/keepkey": "^2.3.7",
     "@web3-onboard/keystone": "^2.3.7",
     "@web3-onboard/ledger": "^2.5.2",

--- a/packages/injected/README.md
+++ b/packages/injected/README.md
@@ -48,7 +48,7 @@ console.log(connectedWallets)
 - Phantom - _Desktop & Mobile_
 - SafePal - _Desktop & Mobile_
 - Zerion - _Desktop & Mobile_
-- OKX Wallet - _Desktop_
+- OKX Wallet - _Desktop & Mobile_
 - Taho (Previously named Tally Ho wallet) - _Desktop_
 - Trust - _Mobile_
 - Opera - _Desktop & Mobile_

--- a/packages/injected/package.json
+++ b/packages/injected/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/injected-wallets",
-  "version": "2.10.6-alpha.2",
+  "version": "2.10.6-alpha.3",
   "description": "Injected wallet module for connecting browser extension and mobile wallets to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/injected/src/wallets.ts
+++ b/packages/injected/src/wallets.ts
@@ -745,7 +745,7 @@ const okxwallet: InjectedWalletModule = {
   getInterface: async () => ({
     provider: createEIP1193Provider(window.okxwallet)
   }),
-  platforms: ['desktop'],
+  platforms: ['all'],
   externalUrl: ProviderExternalUrl.OKXWallet
 }
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.8.12-alpha.2",
+  "version": "2.8.12-alpha.3",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@web3-onboard/common": "^2.3.3",
-    "@web3-onboard/core": "^2.21.1-alpha.2",
+    "@web3-onboard/core": "^2.21.1-alpha.3",
     "use-sync-external-store": "1.0.0"
   },
   "peerDependencies": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.7.11-alpha.2",
+  "version": "2.7.11-alpha.3",
   "description": "A collection of Vue Composables for integrating Web3-Onboard in to a Vue or Nuxt project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -63,7 +63,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.3.3",
-    "@web3-onboard/core": "^2.21.1-alpha.2",
+    "@web3-onboard/core": "^2.21.1-alpha.3",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description
Update the Tx_boost (transaction protection) to the non-alpha url
Update OKX wallet to be available on all devices - Closes: #1900 

### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [x] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation
