### PR TITLE
Release 2.24.13 (develop)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,7 +489,7 @@ jobs:
       - node-staging-build-steps
   build-staging-torus:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:16.18.1
     working_directory: ~/web3-onboard-monorepo/packages/torus
     steps:
       - node-staging-build-steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,7 +241,7 @@ jobs:
       - node-build-steps
   build-torus:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:16.18.1
     working_directory: ~/web3-onboard-monorepo/packages/torus
     steps:
       - node-build-steps

--- a/docs/package.json
+++ b/docs/package.json
@@ -74,7 +74,7 @@
     "@web3-onboard/portis": "^2.1.7",
     "@web3-onboard/sequence": "^2.0.8",
     "@web3-onboard/taho": "^2.0.5",
-    "@web3-onboard/torus": "^2.2.5",
+    "@web3-onboard/torus": "^2.2.6-alpha.1",
     "@web3-onboard/transaction-preview": "^2.0.8",
     "@web3-onboard/trezor": "^2.4.3",
     "@web3-onboard/trust": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-onboard-monorepo",
-  "version": "2.24.12=3",
+  "version": "2.24.13",
   "private": true,
   "workspaces": {
     "packages": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-onboard-monorepo",
-  "version": "2.24.12",
+  "version": "2.24.12=3",
   "private": true,
   "workspaces": {
     "packages": [

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -50,7 +50,7 @@
     "@web3-onboard/portis": "^2.1.6",
     "@web3-onboard/sequence": "^2.0.7",
     "@web3-onboard/taho": "^2.0.5",
-    "@web3-onboard/torus": "^2.2.6-alpha.1",
+    "@web3-onboard/torus": "^2.2.6",
     "@web3-onboard/transaction-preview": "^2.0.7",
     "@web3-onboard/trezor": "^2.4.3",
     "@web3-onboard/trust": "^2.0.3",

--- a/packages/torus/package.json
+++ b/packages/torus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/torus",
-  "version": "2.2.6-alpha.1",
+  "version": "2.2.6",
   "description": "Torus SDK wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
### **✨ Highlights**

- **Update @toruslabs/torus-embed version #1936**
- **Bump postcss from 8.4.6 to 8.4.31 #1938**
- **Bump postcss from 8.4.21 to 8.4.31 in /examples/with-vuejs #1939**
- **Bump postcss from 8.4.24 to 8.4.31 in /examples/with-vite-react #1940**
- **Bump postcss from 8.4.23 to 8.4.31 in /docs #1941**
- **Bump postcss from 8.4.21 to 8.4.31 in /examples/with-sveltekit #1942**
- **Bump postcss from 8.4.19 to 8.4.31 in /packages/demo**

### **📦 Changes per package**

@web3-onboard/torus: 2.2.6