### PR TITLE
fix: Add wallet class to button element

### DIFF
--- a/packages/core/src/views/connect/WalletButton.svelte
+++ b/packages/core/src/views/connect/WalletButton.svelte
@@ -12,6 +12,9 @@
   export let disabled: boolean
 
   let windowWidth: number
+
+  // Lowercase the label and remove special characters
+  export let formattedLabel = label.toLowerCase().replace(/[^a-zA-Z0-9]+/g, '');
 </script>
 
 <style>
@@ -104,7 +107,7 @@
 
 <svelte:window bind:innerWidth={windowWidth} />
 
-<div class="wallet-button-container">
+<div class="wallet-button-container wallet-{formattedLabel}">
   <button
     class="wallet-button-styling"
     class:connected


### PR DESCRIPTION
### Description

Adds the wallet name to the class output of `wallet-button-container`. This is useful in case a wallet needs to be styled/hidden inside the modal.

#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [ ] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [x] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation

### Docs Checklist
- [x] Include a screenshot of any changes ([see docs README on running locally](https://github.com/blocknative/web3-onboard/blob/develop/docs/README.md))
<img width="607" alt="Screenshot 2023-10-23 at 14 27 08" src="https://github.com/blocknative/web3-onboard/assets/5880855/d665dcf3-836e-4d07-8df2-1949ae50b8c6">

- [x] Add/update the appropriate package README (if applicable)
- [x] Add/update the related module in the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) (if applicable)
- [x] Add/update the related package in the `docs/package.json` file (if applicable)

### If this PR includes changes to add an injected wallet or SDK wallet module: 
Please complete the following using the internal demo package.
To run this demo use the command `yarn && yarn dev` to get the project running at `http://localhost:8080/`

#### Tests with demo app (injected)
- [x] send transaction
- [x] switch chains
- [x] sign message
- [x] sign typed message
- [x] disconnect

#### Tests with demo app (SDK)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect