### PR TITLE
Refactor: import @walletconnect/ethereum-provider dynamically

### DIFF
--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletconnect",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "WalletConnect SDK module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/walletconnect/package.json
+++ b/packages/walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/walletconnect",
-  "version": "2.5.3",
+  "version": "2.5.3-alpha.1",
   "description": "WalletConnect SDK module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/walletconnect/src/walletConnect.ts
+++ b/packages/walletconnect/src/walletConnect.ts
@@ -1,4 +1,3 @@
-import { REQUIRED_METHODS } from '@walletconnect/ethereum-provider'
 import { isHexString } from './index.js'
 
 import type { EthereumProviderOptions } from '@walletconnect/ethereum-provider/dist/types/EthereumProvider'
@@ -58,7 +57,7 @@ function walletConnect(options: WalletConnectOptions): WalletInit {
           '@web3-onboard/common'
         )
 
-        const { default: EthereumProvider } = await import(
+        const { default: EthereumProvider, REQUIRED_METHODS } = await import(
           '@walletconnect/ethereum-provider'
         )
 


### PR DESCRIPTION
### Description

The `@walletconnect/ethereum-provider` package is a big dependency, and it was imported twice: statically and dynamically.

I've moved the static import to the dynamic one.

<img width="417" alt="Screenshot 2023-12-21 at 12 50 39" src="https://github.com/blocknative/web3-onboard/assets/381895/5c8dafc8-8451-4d44-8690-0bd5b1b67f02">

#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [ ] Confirm this PR passes Circle CI checks