### PR TITLE
load ledger connect kit via package instead of loader

### DIFF
--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -45,7 +45,7 @@
     "@web3-onboard/injected-wallets": "^2.10.11",
     "@web3-onboard/keepkey": "^2.3.7",
     "@web3-onboard/keystone": "^2.3.7",
-    "@web3-onboard/ledger": "^2.5.3-alpha.1",
+    "@web3-onboard/ledger": "^2.6.0-alpha.1",
     "@web3-onboard/magic": "^2.1.6",
     "@web3-onboard/metamask": "^2.0.2",
     "@web3-onboard/mew-wallet": "^2.0.3",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -45,7 +45,7 @@
     "@web3-onboard/injected-wallets": "^2.10.11",
     "@web3-onboard/keepkey": "^2.3.7",
     "@web3-onboard/keystone": "^2.3.7",
-    "@web3-onboard/ledger": "^2.5.2",
+    "@web3-onboard/ledger": "^2.5.3-alpha.1",
     "@web3-onboard/magic": "^2.1.6",
     "@web3-onboard/metamask": "^2.0.2",
     "@web3-onboard/mew-wallet": "^2.0.3",

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/ledger",
-  "version": "2.5.3-alpha.1",
+  "version": "2.6.0-alpha.1",
   "description": "Ledger hardware wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/ledger/package.json
+++ b/packages/ledger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/ledger",
-  "version": "2.5.2",
+  "version": "2.5.3-alpha.1",
   "description": "Ledger hardware wallet module for connecting to Web3-Onboard. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@ethersproject/providers": "5.5.0",
-    "@ledgerhq/connect-kit-loader": "^1.1.0",
+    "@ledgerhq/connect-kit": "1.1.12",
     "@walletconnect/client": "^1.8.0",
     "@walletconnect/ethereum-provider": "2.9.1",
     "@walletconnect/modal": "2.6.1",

--- a/packages/ledger/src/v1.ts
+++ b/packages/ledger/src/v1.ts
@@ -7,7 +7,7 @@ import {
   ChainId,
   AccountAddress
 } from '@web3-onboard/common'
-import type { EthereumProvider } from '@ledgerhq/connect-kit-loader'
+import type { EthereumProvider } from '@ledgerhq/connect-kit/dist/umd/index.d.ts'
 import type { StaticJsonRpcProvider as StaticJsonRpcProviderType } from '@ethersproject/providers'
 import WalletConnect from '@walletconnect/client'
 import { isHexString, LedgerOptionsWCv1 } from './index.js'
@@ -20,18 +20,13 @@ function ledger(
       label: 'Ledger',
       getIcon: async () => (await import('./icon.js')).default,
       getInterface: async ({ chains, EventEmitter }: GetInterfaceHelpers) => {
-        const {
-          loadConnectKit,
-          SupportedProviders,
-          SupportedProviderImplementations
-        } = await import('@ledgerhq/connect-kit-loader')
+        const connectKit = await import('@ledgerhq/connect-kit/dist/umd')
 
-        const connectKit = await loadConnectKit()
         if (options.enableDebugLogs) {
           connectKit.enableDebugLogs()
         }
         const checkSupportResult = connectKit.checkSupport({
-          providerType: SupportedProviders.Ethereum,
+          providerType: connectKit.SupportedProviders.Ethereum,
           chainId: options?.chainId,
           infuraId: options?.infuraId,
           rpc: options?.rpc
@@ -44,7 +39,7 @@ function ledger(
         // return the Ledger Extension provider
         if (
           checkSupportResult.providerImplementation ===
-          SupportedProviderImplementations.LedgerConnect
+          connectKit.SupportedProviderImplementations.LedgerConnect
         ) {
           return {
             provider: instance

--- a/packages/ledger/src/v1.ts
+++ b/packages/ledger/src/v1.ts
@@ -7,7 +7,7 @@ import {
   ChainId,
   AccountAddress
 } from '@web3-onboard/common'
-import type { EthereumProvider } from '@ledgerhq/connect-kit/dist/umd/index.d.ts'
+import type { EthereumProvider } from '@ledgerhq/connect-kit/dist/umd/index.js'
 import type { StaticJsonRpcProvider as StaticJsonRpcProviderType } from '@ethersproject/providers'
 import WalletConnect from '@walletconnect/client'
 import { isHexString, LedgerOptionsWCv1 } from './index.js'

--- a/packages/ledger/src/v2.ts
+++ b/packages/ledger/src/v2.ts
@@ -4,7 +4,7 @@ import {
   EIP1193Provider,
   ProviderAccounts
 } from '@web3-onboard/common'
-import type { EthereumProvider as LedgerEthereumProvider } from '@ledgerhq/connect-kit/dist/umd/index.d.ts'
+import type { EthereumProvider as LedgerEthereumProvider } from '@ledgerhq/connect-kit/dist/umd/index.js'
 import { isHexString, LedgerOptionsWCv2 } from './index.js'
 import type { JQueryStyleEventEmitter } from 'rxjs/internal/observable/fromEvent'
 

--- a/packages/ledger/src/v2.ts
+++ b/packages/ledger/src/v2.ts
@@ -4,7 +4,7 @@ import {
   EIP1193Provider,
   ProviderAccounts
 } from '@web3-onboard/common'
-import type { EthereumProvider as LedgerEthereumProvider } from '@ledgerhq/connect-kit-loader'
+import type { EthereumProvider as LedgerEthereumProvider } from '@ledgerhq/connect-kit/dist/umd/index.d.ts'
 import { isHexString, LedgerOptionsWCv2 } from './index.js'
 import type { JQueryStyleEventEmitter } from 'rxjs/internal/observable/fromEvent'
 
@@ -30,13 +30,8 @@ function ledger(options?: LedgerOptionsWCv2): WalletInit {
       label: 'Ledger',
       getIcon: async () => (await import('./icon.js')).default,
       getInterface: async ({ chains, EventEmitter }) => {
-        const {
-          loadConnectKit,
-          SupportedProviders,
-          SupportedProviderImplementations
-        } = await import('@ledgerhq/connect-kit-loader')
+        const connectKit = await import('@ledgerhq/connect-kit/dist/umd')
 
-        const connectKit = await loadConnectKit()
         if (options?.enableDebugLogs) {
           connectKit.enableDebugLogs()
         }
@@ -54,7 +49,7 @@ function ledger(options?: LedgerOptionsWCv2): WalletInit {
             : defaultOptionalMethods
 
         const checkSupportResult = connectKit.checkSupport({
-          providerType: SupportedProviders.Ethereum,
+          providerType: connectKit.SupportedProviders.Ethereum,
           walletConnectVersion: 2,
           projectId: options?.projectId,
           chains: requiredChains,
@@ -79,7 +74,7 @@ function ledger(options?: LedgerOptionsWCv2): WalletInit {
         // return the Ledger Extension provider
         if (
           checkSupportResult.providerImplementation ===
-          SupportedProviderImplementations.LedgerConnect
+          connectKit.SupportedProviderImplementations.LedgerConnect
         ) {
           return {
             provider: instance

--- a/packages/ledger/src/v2.ts
+++ b/packages/ledger/src/v2.ts
@@ -15,7 +15,9 @@ const defaultOptionalMethods = [
   'personal_sign',
   'eth_sign',
   'eth_signTypedData',
-  'eth_signTypedData_v4'
+  'eth_signTypedData_v4',
+  'wallet_addEthereumChain',
+  'wallet_switchEthereumChain'
 ]
 
 function ledger(options?: LedgerOptionsWCv2): WalletInit {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2742,6 +2742,14 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.0.tgz#10343b78ef13436818bf3453568a559c0eeb9d48"
   integrity sha512-HUy12FEczoWY2FPubnsm1uOA8tkVWc0j90i47suThV3C9NL2xx69ZAIEU3Ytzs2bwLek9S1Q2S1VQJvA+3Ygkg==
 
+"@ledgerhq/connect-kit@1.1.12":
+  version "1.1.12"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/connect-kit/-/connect-kit-1.1.12.tgz#e6782c207a2c8d1f4db603d090c0bbecef02e5fd"
+  integrity sha512-dmnG2BGBckzaUaqXmkoDxy1+Yvk/simH8NNaZOQaOFk2EfFNsaw5Q3EKrw9tzqjSXmg6t6eGUNPxE0ji9uZprw==
+  dependencies:
+    rollup-plugin-dotenv "0.5.0"
+    uuid "9.0.1"
+
 "@lit-labs/ssr-dom-shim@^1.0.0", "@lit-labs/ssr-dom-shim@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.0.tgz#3361d6b8c4cb2ac426d5794ac7cd9776cd2f0814"
@@ -3487,6 +3495,14 @@
     "@rollup/pluginutils" "^3.1.0"
     magic-string "^0.25.7"
 
+"@rollup/plugin-replace@^5.0.1":
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz#33d5653dce6d03cb24ef98bef7f6d25b57faefdf"
+  integrity sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==
+  dependencies:
+    "@rollup/pluginutils" "^5.0.1"
+    magic-string "^0.30.3"
+
 "@rollup/plugin-typescript@^8.0.0":
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-typescript/-/plugin-typescript-8.3.0.tgz#bc1077fa5897b980fc27e376c4e377882c63e68b"
@@ -3503,6 +3519,15 @@
     "@types/estree" "0.0.39"
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
+
+"@rollup/pluginutils@^5.0.1":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.0.tgz#7e53eddc8c7f483a4ad0b94afb1f7f5fd3c771e0"
+  integrity sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+    estree-walker "^2.0.2"
+    picomatch "^2.3.1"
 
 "@safe-global/safe-apps-provider@^0.17.1":
   version "0.17.1"
@@ -4616,6 +4641,11 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+
+"@types/estree@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
+  integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
 "@types/ethereumjs-util@^5.2.0":
   version "5.2.0"
@@ -8664,6 +8694,11 @@ domexception@^1.0.1:
   dependencies:
     webidl-conversions "^4.0.2"
 
+dotenv@^16.0.3:
+  version "16.4.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.1.tgz#1d9931f1d3e5d2959350d1250efab299561f7f11"
+  integrity sha512-CjA3y+Dr3FyFDOAMnxZEGtnW9KBR2M0JvvUtXNW+dYJL5ROWxP9DUHCwgFqpMk0OXCc0ljhaNTr2w/kutYIcHQ==
+
 drbg.js@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/drbg.js/-/drbg.js-1.0.1.tgz#3e36b6c42b37043823cdbc332d58f31e2445480b"
@@ -12027,6 +12062,13 @@ magic-string@^0.25.7:
   dependencies:
     sourcemap-codec "^1.4.4"
 
+magic-string@^0.30.3:
+  version "0.30.6"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.6.tgz#996e21b42f944e45591a68f0905d6a740a12506c"
+  integrity sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
@@ -14200,6 +14242,14 @@ rlp@^2.0.0, rlp@^2.2.3, rlp@^2.2.4:
   dependencies:
     bn.js "^5.2.0"
 
+rollup-plugin-dotenv@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-dotenv/-/rollup-plugin-dotenv-0.5.0.tgz#c2df297be52f3dcc0ae7fb048e08f906cee112e7"
+  integrity sha512-M2gZqEZebtcKaA7OBdO4UF3WmkI02wVD6UVwoxFlRKoq4/n1Q9Cw6UV8dPvVZYpGQ+ug2JPoogrCLaydIKU96A==
+  dependencies:
+    "@rollup/plugin-replace" "^5.0.1"
+    dotenv "^16.0.3"
+
 rollup-plugin-svelte@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-svelte/-/rollup-plugin-svelte-7.1.0.tgz#d45f2b92b1014be4eb46b55aa033fb9a9c65f04d"
@@ -16010,6 +16060,11 @@ uuid@9.0.0, uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
+uuid@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"


### PR DESCRIPTION
### Description

Loads [@ledgerhq/connect-kit](https://www.npmjs.com/package/@ledgerhq/connect-kit) package via package manager instead of via @ledgerhq/connect-kit-loader (which is deprecated). 

This latest version of @ledgerhq/connect-kit that is now imported fixes this issue: https://github.com/blocknative/web3-onboard/issues/1996


#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [x] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation


#### Tests with demo app (SDK)
- [x] send transaction
- [x] switch chains
- [x] sign message
- [x] sign typed message
- [x] disconnect