### PR TITLE
fix: use css vars for font size (wallet button)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.21.2-alpha.1",
+  "version": "2.21.3-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.21.2",
+  "version": "2.21.2-alpha.1",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/core",
-  "version": "2.21.3-alpha.1",
+  "version": "2.21.3-alpha.2",
   "description": "Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, framework agnostic modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/core/src/views/connect/WalletButton.svelte
+++ b/packages/core/src/views/connect/WalletButton.svelte
@@ -84,7 +84,7 @@
     }
 
     .name {
-      font-size: 1rem;
+      font-size: var(--onboard-font-size-5, var(--font-size-5));
       line-height: 1.25rem;
       text-align: initial;
       max-width: inherit;

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -33,7 +33,7 @@
     "@web3-onboard/capsule": "2.0.1",
     "@web3-onboard/cede-store": "^2.2.0",
     "@web3-onboard/coinbase": "^2.2.6",
-    "@web3-onboard/core": "^2.21.2",
+    "@web3-onboard/core": "^2.21.3-alpha.1",
     "@web3-onboard/dcent": "^2.2.7",
     "@web3-onboard/enkrypt": "^2.0.3",
     "@web3-onboard/fortmatic": "^2.0.18",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -33,7 +33,7 @@
     "@web3-onboard/capsule": "2.0.1",
     "@web3-onboard/cede-store": "^2.2.0",
     "@web3-onboard/coinbase": "^2.2.6",
-    "@web3-onboard/core": "^2.21.3-alpha.1",
+    "@web3-onboard/core": "^2.21.3-alpha.2",
     "@web3-onboard/dcent": "^2.2.7",
     "@web3-onboard/enkrypt": "^2.0.3",
     "@web3-onboard/fortmatic": "^2.0.18",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@web3-onboard/common": "^2.3.3",
-    "@web3-onboard/core": "^2.21.2",
+    "@web3-onboard/core": "^2.21.3-alpha.1",
     "use-sync-external-store": "1.0.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@web3-onboard/common": "^2.3.3",
-    "@web3-onboard/core": "^2.21.3-alpha.1",
+    "@web3-onboard/core": "^2.21.3-alpha.2",
     "use-sync-external-store": "1.0.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/react",
-  "version": "2.8.14-alpha.1",
+  "version": "2.8.14-alpha.2",
   "description": "A collection of React hooks for integrating Web3-Onboard in to React and Next.js projects. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardised spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@web3-onboard/common": "^2.3.3",
-    "@web3-onboard/core": "^2.21.3-alpha.1",
+    "@web3-onboard/core": "^2.21.3-alpha.2",
     "solid-js": "^1.8.1"
   }
 }

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@web3-onboard/common": "^2.3.3",
-    "@web3-onboard/core": "^2.21.0",
+    "@web3-onboard/core": "^2.21.3-alpha.1",
     "solid-js": "^1.8.1"
   }
 }

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/solid",
-  "version": "2.0.1-alpha.1",
+  "version": "2.0.1-alpha.2",
   "description": "A collection of solid Composables for integrating Web3-Onboard in to a Solid project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -62,7 +62,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.3.3",
-    "@web3-onboard/core": "^2.21.3-alpha.1",
+    "@web3-onboard/core": "^2.21.3-alpha.2",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -62,7 +62,7 @@
     "@vueuse/core": "^8.4.2",
     "@vueuse/rxjs": "^8.2.0",
     "@web3-onboard/common": "^2.3.3",
-    "@web3-onboard/core": "^2.21.2",
+    "@web3-onboard/core": "^2.21.3-alpha.1",
     "vue-demi": "^0.12.4"
   },
   "peerDependencies": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@web3-onboard/vue",
-  "version": "2.7.13-alpha.1",
+  "version": "2.7.13-alpha.2",
   "description": "A collection of Vue Composables for integrating Web3-Onboard in to a Vue or Nuxt project. Web3-Onboard makes it simple to connect Ethereum hardware and software wallets to your dapp. Features standardized spec compliant web3 providers for all supported wallets, modern javascript UI with code splitting, CSS customization, multi-chain and multi-account support, reactive wallet state subscriptions and real-time transaction state change notifications.",
   "keywords": [
     "Ethereum",


### PR DESCRIPTION
### Description

Updated `WalletButton` font-size to use css vars instead of a hardcoded value.
- Resolves #2060
- Bumped core version from `2.21.2` → `2.21.3-alpha.1`
- Bumped core version for dependents
  - `packages/demo`
  - `packages/react`
  - `packages/vue`
  - `packages/solid`

### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [x] Run `yarn check-all` to confirm there are not any associated errors
- [x] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation