### PR TITLE
[FIX] -  Keepkey build Node version to 16.20.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
       - node-build-steps
   build-keepkey:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:16.20.2
     working_directory: ~/web3-onboard-monorepo/packages/keepkey
     steps:
       - node-build-steps
@@ -247,7 +247,7 @@ jobs:
       - node-build-steps
   build-trezor:
     docker:
-      - image: cimg/node:18.19.1
+      - image: cimg/node:18.0.0
     working_directory: ~/web3-onboard-monorepo/packages/trezor
     steps:
       - node-build-steps
@@ -421,7 +421,7 @@ jobs:
       - node-build-steps
   build-bitkeep:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:16.13.1
     working_directory: ~/web3-onboard-monorepo/packages/bitkeep
     steps:
       - node-build-steps
@@ -489,7 +489,7 @@ jobs:
       - node-staging-build-steps
   build-staging-keepkey:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:16.20.2
     working_directory: ~/web3-onboard-monorepo/packages/keepkey
     steps:
       - node-staging-build-steps
@@ -531,7 +531,7 @@ jobs:
       - node-staging-build-steps
   build-staging-trezor:
     docker:
-      - image: cimg/node:18.19.1
+      - image: cimg/node:18.0.0
     working_directory: ~/web3-onboard-monorepo/packages/trezor
     steps:
       - node-staging-build-steps
@@ -705,7 +705,7 @@ jobs:
       - node-staging-build-steps
   build-staging-bitkeep:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:16.13.1
     working_directory: ~/web3-onboard-monorepo/packages/bitkeep
     steps:
       - node-staging-build-steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
       - node-build-steps
   build-trezor:
     docker:
-      - image: cimg/node:18.0.0
+      - image: cimg/node:18.19.1
     working_directory: ~/web3-onboard-monorepo/packages/trezor
     steps:
       - node-build-steps
@@ -421,7 +421,7 @@ jobs:
       - node-build-steps
   build-bitkeep:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:16.20.2
     working_directory: ~/web3-onboard-monorepo/packages/bitkeep
     steps:
       - node-build-steps
@@ -531,7 +531,7 @@ jobs:
       - node-staging-build-steps
   build-staging-trezor:
     docker:
-      - image: cimg/node:18.0.0
+      - image: cimg/node:18.19.1
     working_directory: ~/web3-onboard-monorepo/packages/trezor
     steps:
       - node-staging-build-steps
@@ -705,7 +705,7 @@ jobs:
       - node-staging-build-steps
   build-staging-bitkeep:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:16.20.2
     working_directory: ~/web3-onboard-monorepo/packages/bitkeep
     steps:
       - node-staging-build-steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -421,7 +421,7 @@ jobs:
       - node-build-steps
   build-bitkeep:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:16.13.1
     working_directory: ~/web3-onboard-monorepo/packages/bitkeep
     steps:
       - node-build-steps
@@ -705,7 +705,7 @@ jobs:
       - node-staging-build-steps
   build-staging-bitkeep:
     docker:
-      - image: cimg/node:16.20.2
+      - image: cimg/node:16.13.1
     working_directory: ~/web3-onboard-monorepo/packages/bitkeep
     steps:
       - node-staging-build-steps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,7 @@ jobs:
       - node-build-steps
   build-trezor:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:18.0.0
     working_directory: ~/web3-onboard-monorepo/packages/trezor
     steps:
       - node-build-steps
@@ -450,8 +450,6 @@ jobs:
     steps:
       - node-build-steps
 
-
-
   # Build staging/Alpha releases
   build-staging-core:
     docker:
@@ -533,7 +531,7 @@ jobs:
       - node-staging-build-steps
   build-staging-trezor:
     docker:
-      - image: cimg/node:16.13.1
+      - image: cimg/node:18.0.0
     working_directory: ~/web3-onboard-monorepo/packages/trezor
     steps:
       - node-staging-build-steps


### PR DESCRIPTION
### Description
Keepkey build Node version to 16.20.2 which is causing build errors
