### PR TITLE
Update node version for metamask within CCI to 18.19.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,7 @@ jobs:
       - node-build-steps
   build-metamask:
     docker:
-      - image: cimg/node:18.8.0
+      - image: cimg/node:18.19.1
     working_directory: ~/web3-onboard-monorepo/packages/metamask
     steps:
       - node-build-steps
@@ -711,7 +711,7 @@ jobs:
       - node-staging-build-steps
   build-staging-metamask:
     docker:
-      - image: cimg/node:18.8.0
+      - image: cimg/node:18.19.1
     working_directory: ~/web3-onboard-monorepo/packages/metamask
     steps:
       - node-staging-build-steps


### PR DESCRIPTION
### Description
Update node version for metamask within CCI to 18.19.1
