### PR TITLE
Update Capsule modalProps type

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -55,7 +55,7 @@
     "@web3-onboard/arcana-auth": "^2.0.0",
     "@web3-onboard/bitget": "^2.0.0",
     "@web3-onboard/blocto": "^2.0.0",
-    "@web3-onboard/capsule": "^2.0.2",
+    "@web3-onboard/capsule": "^2.0.3-alpha.1",
     "@web3-onboard/cede-store": "^2.2.0",
     "@web3-onboard/coinbase": "^2.2.7",
     "@web3-onboard/core": "^2.21.6",

--- a/docs/src/routes/docs/[...4]wallets/[...5]capsule/+page.md
+++ b/docs/src/routes/docs/[...4]wallets/[...5]capsule/+page.md
@@ -45,7 +45,7 @@ type CapsuleInitOptions = {
   constructorOpts?: Partial<ConstructorOpts>
   appName: string
   /** @optional capsule modal props */
-  modalProps?: Partial<CapsuleModalV2Props>
+  modalProps?: Partial<CapsuleModalPropsForInit>
 }
 ```
 ## Usage

--- a/packages/capsule/src/types.ts
+++ b/packages/capsule/src/types.ts
@@ -9,9 +9,12 @@ import type { ConstructorOpts, Environment, CapsuleModalV2Props } from '@usecaps
  * @property {string} [apiKey] - API key is necessary for performing transactions and wallet creation.
  *           This key needs to be obtained by completing a form available at https://7f4shq8oyfd.typeform.com/to/F86oVLhb.
  */
+
+export type CapsuleModalPropsForInit = Omit<CapsuleModalV2Props,'isOpen' | 'capsule'>;
+
 export type CapsuleInitOptions = {
   environment: Environment
   apiKey: string,
   constructorOpts?: Partial<ConstructorOpts>
-  modalProps?: Partial<CapsuleModalV2Props>
+  modalProps?: Partial<CapsuleModalPropsForInit>
 }


### PR DESCRIPTION
Add new type that Omits `isOpen` and `capsule` keys from `CapsuleModalV2Props` inline with the wagmi v1 and v2 changes made to omit the same keys from `CapsuleModalProps`.


#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [x] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [ ] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [ ] Run `yarn check-all` to confirm there are not any associated errors
- [ ] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation

### Docs Checklist
- [ ] Include a screenshot of any changes ([see docs README on running locally](https://github.com/blocknative/web3-onboard/blob/develop/docs/README.md))
- [ ] Add/update the appropriate package README (if applicable)
- [ ] Add/update the related module in the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) (if applicable)
- [ ] Add/update the related package in the `docs/package.json` file (if applicable)

### If this PR includes changes to add an injected wallet or SDK wallet module: 
Please complete the following using the internal demo package.
To run this demo use the command `yarn && yarn dev` to get the project running at `http://localhost:8080/`

#### Tests with demo app (injected)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect

#### Tests with demo app (SDK)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect