### PR TITLE
Fix: updated uauthOptions in docs demo

### DIFF
--- a/docs/src/lib/services/onboard.js
+++ b/docs/src/lib/services/onboard.js
@@ -118,8 +118,8 @@ const intiOnboard = async theme => {
   const finoaconnect = finoaConnectModule(finoaConnectOptions)
 
   const uauthOptions = {
-    clientID: 'a25c3a65-a1f2-46cc-a515-a46fe7acb78c',
-    redirectUri: 'http://localhost:8080/',
+    clientID: "a7371c4a-a61e-4fac-af48-4471c2e69e93",
+    redirectUri: "https://onboard.blocknative.com",
     scope: 'openid wallet email:optional humanity_check:optional profile:optional social:optional',
     walletConnectProjectId: 'f6bd6e2911b56f5ac3bc8b2d0e2d7ad5'
   }


### PR DESCRIPTION
### Description
Updated the `clientID` and `redirectUri` within uauthOptions for the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) to fix the invalid redirect URI issue on https://onboard.blocknative.com/examples/connect-wallet


### Checklist
- [ ] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [x] Check the box that allows repo maintainers to update this PR
- [x] Test locally to make sure this feature/fix works
- [ ] Run `yarn check-all` to confirm there are not any associated errors
- [ ] Confirm this PR passes Circle CI checks
- [x] Add or update relevant information in the documentation

### Docs Checklist
- [ ] Include a screenshot of any changes ([see docs README on running locally](https://github.com/blocknative/web3-onboard/blob/develop/docs/README.md))
- [ ] Add/update the appropriate package README (if applicable)
- [x] Add/update the related module in the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) (if applicable)
- [ ] Add/update the related package in the `docs/package.json` file (if applicable)

### If this PR includes changes to add an injected wallet or SDK wallet module: 
Please complete the following using the internal demo package.
To run this demo use the command `yarn && yarn dev` to get the project running at `http://localhost:8080/`

#### Tests with demo app (injected)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect

#### Tests with demo app (SDK)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect