### PR TITLE
Add null check to prevent potential runtime errors

### DIFF
--- a/packages/injected/src/helpers.ts
+++ b/packages/injected/src/helpers.ts
@@ -40,7 +40,7 @@ export const isWalletAvailable = (
   // For multiple injected providers, check providers array
   // example coinbase inj wallet pushes over-ridden wallets
   // into a providers array at window.ethereum
-  return !!provider.providers?.some(provider =>
+  return Array.isArray(provider.providers) && !!provider.providers?.some(provider =>
     checkProviderIdentity({ provider, device })
   )
 }

--- a/packages/injected/src/wallets.ts
+++ b/packages/injected/src/wallets.ts
@@ -581,7 +581,7 @@ const bitget: InjectedWalletModule = {
   label: ProviderLabel.Bitget,
   injectedNamespace: InjectedNameSpace.Bitget,
   checkProviderIdentity: ({ provider }) =>
-    !!provider && !!provider['ethereum'][ProviderIdentityFlag.Bitget],
+    !!provider && !!provider['ethereum'] && !!provider['ethereum'][ProviderIdentityFlag.Bitget],
   getIcon: async () => (await import('./icons/bitget.js')).default,
   getInterface: async () => ({
     provider: window.bitkeep && window.bitkeep.ethereum


### PR DESCRIPTION
helpers.ts:

```js
-    return !!provider.providers?.some(provider => checkProviderIdentity({ provider, device }));
+    return Array.isArray(provider.providers) && !!provider.providers.some(provider => checkProviderIdentity({ provider, device }));
```

wallets.ts:

```js
-    checkProviderIdentity: ({ provider }) => !!provider && !!provider['ethereum'][ProviderIdentityFlag.Bitget],
+    checkProviderIdentity: ({ provider }) => !!provider && !!provider['ethereum'] && !!provider['ethereum'][ProviderIdentityFlag.Bitget]
```