### PR TITLE
Fix: preserve wallet operation return values in Vue useOnboard composable

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -76,16 +76,20 @@ const useOnboard = (): OnboardComposable => {
 
   const connectWallet = async (options?: ConnectOptions) => {
     connectingWallet.value = true
-    await (web3Onboard as OnboardAPI).connectWallet(options)
+    const walletState = await (web3Onboard as OnboardAPI).connectWallet(options)
     lastConnectionTimestamp.value = Date.now()
     connectingWallet.value = false
+    return walletState
   }
 
   const disconnectWallet = async (wallet: DisconnectOptions) => {
     connectingWallet.value = true
-    await (web3Onboard as OnboardAPI).disconnectWallet(wallet)
+    const walletState = await (web3Onboard as OnboardAPI).disconnectWallet(
+      wallet
+    )
     updateAlreadyConnectedWallets()
     connectingWallet.value = false
+    return walletState
   }
 
   const disconnectConnectedWallet = async () => {
@@ -115,8 +119,9 @@ const useOnboard = (): OnboardComposable => {
 
   const setChain = async (options: SetChainOptions) => {
     settingChain.value = true
-    await (web3Onboard as OnboardAPI).setChain(options)
+    const success = await (web3Onboard as OnboardAPI).setChain(options)
     settingChain.value = false
+    return success
   }
 
   return {

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -20,15 +20,15 @@ type SetChainOptions = {
 
 interface OnboardComposable {
   alreadyConnectedWallets: ReadonlyRef<string[]>
-  connectWallet: (options?: ConnectOptions) => Promise<void>
+  connectWallet: (options?: ConnectOptions) => Promise<WalletState[]>
   connectedChain: ComputedRef<ConnectedChain | null>
   connectedWallet: ComputedRef<WalletState | null>
   connectingWallet: ReadonlyRef<boolean>
-  disconnectWallet: (wallet: DisconnectOptions) => Promise<void>
+  disconnectWallet: (wallet: DisconnectOptions) => Promise<WalletState[]>
   disconnectConnectedWallet: () => Promise<void>
   getChain: (walletLabel: string) => ConnectedChain | null
   lastConnectionTimestamp: ReadonlyRef<number>
-  setChain: (options: SetChainOptions) => Promise<void>
+  setChain: (options: SetChainOptions) => Promise<boolean>
   settingChain: ReadonlyRef<boolean>
   wallets: ReadonlyRef<WalletState[]>
 }

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -10,9 +10,9 @@ import type { Ref, ComputedRef } from 'vue-demi'
 type ReadonlyRef<T> = Readonly<Ref<T>>
 
 type SetChainOptions = {
-  chainId: string
+  chainId: string | number
   chainNamespace?: string
-  wallet: string
+  wallet?: WalletState['label']
   rpcUrl?: string
   label?: string
   token?: string


### PR DESCRIPTION
### Description
Preserve return values from core package operations in Vue composable
- `connectWallet` and `disconnectWallet` returns `Promise<WalletState[]>`
- `setChain` returns `Promise<boolean>`

Updated `SetChainOptions` to match `OnboardAPI.setChain` args

<!-- Add a description of the fix or feature here -->


#### **_PLEASE NOTE- Checklist must be complete prior to review._**
### Checklist
- [ ] Increment the version field in `package.json` of the package you have made changes in following [semantic versioning](https://semver.org/) and using alpha release tagging
- [ ] Check the box that allows repo maintainers to update this PR
- [ ] Test locally to make sure this feature/fix works
- [ ] Run `yarn check-all` to confirm there are not any associated errors
- [ ] Confirm this PR passes Circle CI checks
- [ ] Add or update relevant information in the documentation

### Docs Checklist
- [ ] Include a screenshot of any changes ([see docs README on running locally](https://github.com/blocknative/web3-onboard/blob/develop/docs/README.md))
- [ ] Add/update the appropriate package README (if applicable)
- [ ] Add/update the related module in the [docs demo](https://github.com/blocknative/web3-onboard/blob/develop/docs/src/lib/services/onboard.js) (if applicable)
- [ ] Add/update the related package in the `docs/package.json` file (if applicable)

### If this PR includes changes to add an injected wallet or SDK wallet module: 
Please complete the following using the internal demo package.
To run this demo use the command `yarn && yarn dev` to get the project running at `http://localhost:8080/`

#### Tests with demo app (injected)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect

#### Tests with demo app (SDK)
- [ ] send transaction
- [ ] switch chains
- [ ] sign message
- [ ] sign typed message
- [ ] disconnect